### PR TITLE
blinky: Fix compilation failure

### DIFF
--- a/Projects/blinky/CMakeLists.txt
+++ b/Projects/blinky/CMakeLists.txt
@@ -42,6 +42,7 @@ endif()
 
 add_subdirectory(../../Middleware/ARM ${CMAKE_BINARY_DIR}/Middleware/ARM)
 add_subdirectory(../../Bsp ${CMAKE_BINARY_DIR}/Bsp)
+add_subdirectory(../../Config ${CMAKE_BINARY_DIR}/Config)
 
 target_compile_definitions(arm-corstone-platform-bsp
     INTERFACE
@@ -65,6 +66,7 @@ target_compile_definitions(freertos_config
 target_link_libraries(freertos_config
     INTERFACE
         tfm-ns-interface
+        app-config
 )
 
 set( FREERTOS_HEAP "3" CACHE STRING "" FORCE)


### PR DESCRIPTION
blinky: Fix compilation failure

Description
-----------
Add missing `app-config` interface library dependency to `freertos_config` interface library.

Test Steps
-----------
Verified changes on Corstone-300 platform.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
