### PR TITLE
Add new CMake module to generate AWS update digest and signature

### DIFF
--- a/Middleware/AWS/cmake/GenerateAWSUpdateDigestAndSignature.cmake
+++ b/Middleware/AWS/cmake/GenerateAWSUpdateDigestAndSignature.cmake
@@ -1,0 +1,41 @@
+# Copyright 2023 Arm Limited and/or its affiliates
+# <open-source-office@arm.com>
+# SPDX-License-Identifier: MIT
+
+include(ExternalProject)
+
+ExternalProject_Get_Property(tf-m-build BINARY_DIR)
+
+# This function is meant to generate the AWS update signature and digest
+# for the <update_target_name> input parameter, the name of the signature
+# and digest to be generated are passed to the function as <digest_name>
+# and <signature_name>.
+function(iot_reference_arm_corstone3xx_generate_aws_update_digest_and_signature target update_target_name digest_name signature_name)
+    add_custom_command(
+        TARGET
+            ${target}
+        POST_BUILD
+        DEPENDS
+            $<TARGET_FILE_DIR:${target}>/${update_target_name}.bin
+        COMMAND
+            openssl dgst -sha256 -binary
+                -out  $<TARGET_FILE_DIR:${target}>/${digest_name}.bin
+                $<TARGET_FILE_DIR:${target}>/${update_target_name}.bin
+        COMMAND
+            openssl pkeyutl -sign
+                -pkeyopt digest:sha256
+                -pkeyopt rsa_padding_mode:pss
+                -pkeyopt rsa_mgf1_md:sha256
+                -inkey ${BINARY_DIR}/install/image_signing/keys/root-RSA-2048_1.pem
+                -in  $<TARGET_FILE_DIR:${target}>/${digest_name}.bin
+                -out  $<TARGET_FILE_DIR:${target}>/${signature_name}.bin
+        COMMAND
+            openssl base64 -A
+                -in  $<TARGET_FILE_DIR:${target}>/${signature_name}.bin
+                -out  $<TARGET_FILE_DIR:${target}>/${signature_name}.txt
+        COMMAND
+            ${CMAKE_COMMAND} -E echo "Use this base 64 encoded signature in OTA job:"
+        COMMAND
+            ${CMAKE_COMMAND} -E cat  $<TARGET_FILE_DIR:${target}>/${signature_name}.txt
+    )
+endfunction()

--- a/Projects/aws-iot-example/CMakeLists.txt
+++ b/Projects/aws-iot-example/CMakeLists.txt
@@ -324,30 +324,7 @@ add_custom_command(
                 ${CMAKE_CURRENT_BINARY_DIR}/aws-iot-example-update_signed.bin
 )
 
-add_custom_command(
-    TARGET
-        aws-iot-example
-    POST_BUILD
-    DEPENDS
-        ${CMAKE_CURRENT_BINARY_DIR}/aws-iot-example-update_signed.bin
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/Middleware/AWS/cmake)
+include(GenerateAWSUpdateDigestAndSignature)
 
-    BYPRODUCTS
-        ${CMAKE_CURRENT_BINARY_DIR}/update-digest.bin
-        ${CMAKE_CURRENT_BINARY_DIR}/update-signature.bin
-        ${CMAKE_CURRENT_BINARY_DIR}/update-signature.txt
-
-    COMMAND
-        openssl dgst -sha256 -binary -out ${CMAKE_CURRENT_BINARY_DIR}/update-digest.bin ${CMAKE_CURRENT_BINARY_DIR}/aws-iot-example-update_signed.bin
-
-    COMMAND
-        openssl pkeyutl -sign -pkeyopt digest:sha256 -pkeyopt rsa_padding_mode:pss -pkeyopt rsa_mgf1_md:sha256 -inkey ${BINARY_DIR}/install/image_signing/keys/root-RSA-2048_1.pem -in ${CMAKE_CURRENT_BINARY_DIR}/update-digest.bin -out ${CMAKE_CURRENT_BINARY_DIR}/update-signature.bin
-
-    COMMAND
-        openssl base64 -A -in ${CMAKE_CURRENT_BINARY_DIR}/update-signature.bin -out ${CMAKE_CURRENT_BINARY_DIR}/update-signature.txt
-
-    COMMAND
-        ${CMAKE_COMMAND} -E echo "Use this base 64 encoded signature in OTA job:"
-
-    COMMAND
-        ${CMAKE_COMMAND} -E cat ${CMAKE_CURRENT_BINARY_DIR}/update-signature.txt
-)
+iot_reference_arm_corstone3xx_generate_aws_update_digest_and_signature(aws-iot-example aws-iot-example-update_signed update-digest update-signature)


### PR DESCRIPTION
<!--- Title -->

Description
-----------
A new CMake module (GenerateAWSUpdateDigestAndSignature.cmake) is introduced to be used to generate AWS update digest and update signature to be used for AWS OTA update.

This change would enhance code re-usability and decrease code duplication within the applications by using the newly introduced CMake module rather than duplicating the same code every time AWS Update digest and signature are to be generated. 

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
