### PR TITLE
Add signing merging cmake modules

### DIFF
--- a/.github/.cSpellWords.txt
+++ b/.github/.cSpellWords.txt
@@ -84,6 +84,7 @@ RIHN
 RSAES
 RSASSA
 SECP
+srecord
 srtp
 SRTP
 tinycbor

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,10 +32,11 @@ jobs:
         shell: bash
         run: |
           pip install cmake ninja imgtool cffi intelhex cbor2 cbor jinja2 PyYaml pyelftools
+          sudo apt-get -y update
+          sudo apt-get -y install srecord
       - name: Install GNU Arm toolchain
         shell: bash
         run: |
-          sudo apt-get -y update
           sudo apt-get -y install gcc-arm-none-eabi
       - name: Generate dummy device credentials
         shell: bash
@@ -55,10 +56,7 @@ jobs:
         shell: bash
         run: |
           tar -czf gnu_build.tar.gz \
-          build/bootloader/bl2.axf \
-          build/secure_partition/tfm_s_signed.bin \
-          build/Projects/aws-iot-example/aws-iot-example.axf \
-          build/Projects/aws-iot-example/aws-iot-example_signed.bin \
+          build/Projects/aws-iot-example/aws-iot-example_merged.elf \
           build/Projects/aws-iot-example/aws-iot-example-update_signed.bin \
           build/Projects/aws-iot-example/update-signature.txt
       - name: Upload Build Artifacts

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -80,14 +80,9 @@ build-applications:
     - ./Tools/scripts/build.sh aws-iot-example --toolchain $TOOLCHAIN --certificate_path $PWD/certificate.pem  --private_key_path $PWD/private_key.pem
     - |
       tar -czf ${TOOLCHAIN}_build.tar.gz \
-        build/bootloader/bl2.axf \
-        build/secure_partition/tfm_s_signed.bin \
-        build/secure_partition/encrypted_provisioning_bundle.bin \
-        build/Projects/aws-iot-example/aws-iot-example.axf \
-        build/Projects/aws-iot-example/aws-iot-example_signed.bin \
+        build/Projects/aws-iot-example/aws-iot-example_merged.elf \
         build/Projects/aws-iot-example/aws-iot-example-update_signed.bin \
         build/Projects/aws-iot-example/update-signature.txt \
-        build/Projects/aws-iot-example/provisioning_data/provisioning_data.bin \
         Config/aws_configs
   artifacts:
     paths:

--- a/Bsp/CMakeLists.txt
+++ b/Bsp/CMakeLists.txt
@@ -4,6 +4,15 @@
 
 add_subdirectory(arm-corstone-platform-bsp)
 
+# Target specific image loading addresses
+if(ARM_CORSTONE_BSP_TARGET_PLATFORM STREQUAL "corstone300")
+    set(BL2_IMAGE_LOAD_ADDRESS 0x00000000 PARENT_SCOPE)
+    set(S_IMAGE_LOAD_ADDRESS 0x11000000 PARENT_SCOPE)
+    set(NS_IMAGE_LOAD_ADDRESS 0x01060000 PARENT_SCOPE)
+    set(S_PROVISIONING_BUNDLE_LOAD_ADDRESS 0x10022000 PARENT_SCOPE)
+    set(NS_PROVISIONING_BUNDLE_LOAD_ADDRESS 0x210FF000 PARENT_SCOPE)
+endif()
+
 # BSP serial library
 
 add_library(fri-bsp STATIC)

--- a/Docs/development-environment.md
+++ b/Docs/development-environment.md
@@ -51,6 +51,12 @@ git submodule update --init --recursive
     ```bash
     deactivate
     ```
+* Installing required libraries
+
+    ```bash
+    sudo apt install srecord
+    sudo apt install binutils
+    ```
 * Installing a toolchain
 
   This project supports the Arm Compiler for Embedded (armclang) and the Arm

--- a/Middleware/ARM/TF-M/cmake/MergeTfmImages.cmake
+++ b/Middleware/ARM/TF-M/cmake/MergeTfmImages.cmake
@@ -1,0 +1,50 @@
+# Copyright 2023 Arm Limited and/or its affiliates
+# <open-source-office@arm.com>
+# SPDX-License-Identifier: MIT
+
+include(ConvertElfToBin)
+include(ExternalProject)
+
+ExternalProject_Get_Property(tf-m-build BINARY_DIR)
+
+# To merge the bootloader image, TF-M secure image, non-secure user application image,
+# secure and non-secure provsioning bundle images into one image, their addresses are
+# needed. As the addresses are defined in their respective linker scripts, there is no
+# simple way to programmatically get them, so they need to be specified by the user project.
+# Order: <bootloader>, <signed secure TF-M firmware>, <signed non-secure user app>, <secure provisioning bundle address>, <non-secure provisioning data load address> (optional), <non-secure provisioning data path> (optional).
+
+# This function is making use of CMake optional arguments feature, the reason why this feature
+# is used is that not every application will need to pass the non-secure provisioning data load address
+# and the non-secure provisioning data path to this function.
+# ARGV5 is mapped to non-secure provisioning data load address.
+# ARGV6 is mapped to non-secure provisioning data path.
+function(iot_reference_arm_corstone3xx_tf_m_merge_images target bl2_address tfm_s_address ns_address s_prov_bundle_address)
+    if(DEFINED ARGV5)
+        set(ns_provisioning_data_param ${ARGV6} -Binary -offset ${ARGV5})
+    else()
+        set(ns_provisioning_data_param "")
+    endif()
+    find_program(srec_cat NAMES srec_cat REQUIRED)
+    find_program(objcopy NAMES arm-none-eabi-objcopy objcopy REQUIRED)
+    add_custom_command(
+        TARGET
+            ${target}
+        POST_BUILD
+        DEPENDS
+            $<TARGET_FILE_DIR:${target}>/${target}_signed.bin
+        COMMAND
+            ${srec_cat} ${BINARY_DIR}/install/outputs/bl2.bin -Binary -offset ${bl2_address}
+                ${BINARY_DIR}/install/outputs/tfm_s_signed.bin -Binary -offset ${tfm_s_address}
+                $<TARGET_FILE_DIR:${target}>/${target}_signed.bin -Binary -offset ${ns_address}
+                ${ns_provisioning_data_param}
+                ${CMAKE_BINARY_DIR}/Middleware/ARM/TF-M/tf-m-build-prefix/src/tf-m-build-build/install/outputs/encrypted_provisioning_bundle.bin -Binary -offset ${s_prov_bundle_address}
+                -o $<TARGET_FILE_DIR:${target}>/${target}_merged.hex
+        COMMAND
+            ${objcopy} -I ihex -O elf32-little
+                $<TARGET_FILE_DIR:${target}>/${target}_merged.hex
+                $<TARGET_FILE_DIR:${target}>/${target}_merged.elf
+        COMMAND
+            ${CMAKE_COMMAND} -E echo "-- merged: $<TARGET_FILE_DIR:${target}>/${target}_merged.elf"
+        VERBATIM
+    )
+endfunction()

--- a/Middleware/ARM/TF-M/cmake/SignTfmImage.cmake
+++ b/Middleware/ARM/TF-M/cmake/SignTfmImage.cmake
@@ -33,21 +33,6 @@ function(iot_reference_arm_corstone3xx_tf_m_sign_image target signed_target_name
                 --confirm
                 $<TARGET_FILE_DIR:${target}>/${target}_unsigned.bin
                 $<TARGET_FILE_DIR:${target}>/${signed_target_name}.bin
-        COMMAND
-        # Copy the bootloader image
-        ${CMAKE_COMMAND} -E copy
-            ${BINARY_DIR}/install/outputs/bl2.axf
-            ${CMAKE_BINARY_DIR}/bootloader/bl2.axf
-        COMMAND
-        # Copy the signed TF-M image
-        ${CMAKE_COMMAND} -E copy
-            ${BINARY_DIR}/install/outputs/tfm_s_signed.bin
-            ${CMAKE_BINARY_DIR}/secure_partition/tfm_s_signed.bin
-        COMMAND
-        # Copy the encrypted provisioning bundle image
-        ${CMAKE_COMMAND} -E copy
-            ${BINARY_DIR}/install/outputs/encrypted_provisioning_bundle.bin
-            ${CMAKE_BINARY_DIR}/secure_partition/encrypted_provisioning_bundle.bin
 
         COMMAND
             ${CMAKE_COMMAND} -E echo "-- signed: $<TARGET_FILE_DIR:${target}>/${signed_target_name}.bin"

--- a/Middleware/ARM/TF-M/cmake/SignTfmImage.cmake
+++ b/Middleware/ARM/TF-M/cmake/SignTfmImage.cmake
@@ -1,0 +1,56 @@
+# Copyright 2023 Arm Limited and/or its affiliates
+# <open-source-office@arm.com>
+# SPDX-License-Identifier: MIT
+
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/Tools/cmake)
+include(ConvertElfToBin)
+include(ExternalProject)
+
+ExternalProject_Get_Property(tf-m-build BINARY_DIR)
+
+function(iot_reference_arm_corstone3xx_tf_m_sign_image target signed_target_name version pad)
+    if(${pad})
+        set(pad_option "--pad")
+    else()
+        set(pad_option "")
+    endif()
+    target_elf_to_bin(${target} ${target}_unsigned)
+    add_custom_command(
+        TARGET
+            ${target}
+        POST_BUILD
+        DEPENDS
+            $<TARGET_FILE_DIR:${target}>/${target}.bin
+        COMMAND
+            # Sign the non-secure (application) image for TF-M bootloader (BL2)
+            python3 ${BINARY_DIR}/install/image_signing/scripts/wrapper/wrapper.py
+                -v ${version}
+                --layout ${BINARY_DIR}/install/image_signing/layout_files/signing_layout_ns.o
+                -k ${BINARY_DIR}/install/image_signing/keys/root-RSA-2048_1.pem
+                --public-key-format full
+                --align 1 --pad-header ${pad_option} -H 0x400 -s auto
+                --measured-boot-record
+                --confirm
+                $<TARGET_FILE_DIR:${target}>/${target}_unsigned.bin
+                $<TARGET_FILE_DIR:${target}>/${signed_target_name}.bin
+        COMMAND
+        # Copy the bootloader image
+        ${CMAKE_COMMAND} -E copy
+            ${BINARY_DIR}/install/outputs/bl2.axf
+            ${CMAKE_BINARY_DIR}/bootloader/bl2.axf
+        COMMAND
+        # Copy the signed TF-M image
+        ${CMAKE_COMMAND} -E copy
+            ${BINARY_DIR}/install/outputs/tfm_s_signed.bin
+            ${CMAKE_BINARY_DIR}/secure_partition/tfm_s_signed.bin
+        COMMAND
+        # Copy the encrypted provisioning bundle image
+        ${CMAKE_COMMAND} -E copy
+            ${BINARY_DIR}/install/outputs/encrypted_provisioning_bundle.bin
+            ${CMAKE_BINARY_DIR}/secure_partition/encrypted_provisioning_bundle.bin
+
+        COMMAND
+            ${CMAKE_COMMAND} -E echo "-- signed: $<TARGET_FILE_DIR:${target}>/${signed_target_name}.bin"
+        VERBATIM
+    )
+endfunction()

--- a/Projects/aws-iot-example/CMakeLists.txt
+++ b/Projects/aws-iot-example/CMakeLists.txt
@@ -247,6 +247,7 @@ endif()
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/Middleware/ARM/TF-M/cmake)
 include(SignTfmImage)
+include(MergeTfmImages)
 
 # The non-secure application image should be padded while being signed
 # Hence, passing "TRUE" as the input parameter to the pad option of sign function.
@@ -257,6 +258,12 @@ iot_reference_arm_corstone3xx_tf_m_sign_image(aws-iot-example aws-iot-example_si
 # 2) the trailer that keeps track of boot and update statuses should not be overwritten
 # Hence, passing "FALSE" as the input parameter for the pad option to the sign function.
 iot_reference_arm_corstone3xx_tf_m_sign_image(aws-iot-example aws-iot-example-update_signed ${MCUBOOT_IMAGE_VERSION_NS_UPDATE} FALSE)
+
+# A user project that consumes the ARM FRI needs to explicitly provide
+# addresses in order to merge images for TF-M. The addresses cannot
+# be easily programmatically extracted as they are defined in the linker
+# scripts.
+iot_reference_arm_corstone3xx_tf_m_merge_images(aws-iot-example ${BL2_IMAGE_LOAD_ADDRESS} ${S_IMAGE_LOAD_ADDRESS} ${NS_IMAGE_LOAD_ADDRESS} ${S_PROVISIONING_BUNDLE_LOAD_ADDRESS} ${NS_PROVISIONING_BUNDLE_LOAD_ADDRESS} ${CMAKE_BINARY_DIR}/Projects/aws-iot-example/provisioning_data/provisioning_data.bin)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/Middleware/AWS/cmake)
 include(GenerateAWSUpdateDigestAndSignature)

--- a/Projects/aws-iot-example/CMakeLists.txt
+++ b/Projects/aws-iot-example/CMakeLists.txt
@@ -187,33 +187,6 @@ target_link_libraries(integration-test-task
 
 add_subdirectory(${MIDDLEWARE_DIR}/AWS ${CMAKE_BINARY_DIR}/Middleware/AWS)
 
-# Copy tf-m binaries at the root
-ExternalProject_Get_Property(tf-m-build BINARY_DIR)
-ExternalProject_Get_Property(tf-m-build SOURCE_DIR)
-
-add_custom_target(tfm-binaries
-  BYPRODUCTS
-    ${CMAKE_BINARY_DIR}/bootloader/bl2.axf
-    ${CMAKE_BINARY_DIR}/secure_partition/tfm_s.axf
-    ${CMAKE_BINARY_DIR}/secure_partition/tfm_s_unsigned.bin
-    ${CMAKE_BINARY_DIR}/secure_partition/tfm_s_signed.bin
-
-  COMMAND ${CMAKE_COMMAND} -E copy
-    ${BINARY_DIR}/install/outputs/bl2.axf
-    "${CMAKE_BINARY_DIR}/bootloader/bl2${CMAKE_EXECUTABLE_SUFFIX}"
-
-    COMMAND ${CMAKE_COMMAND} -E copy
-    ${BINARY_DIR}/install/outputs/tfm_s_signed.bin
-    "${CMAKE_BINARY_DIR}/secure_partition/tfm_s_signed.bin"
-
-    COMMAND ${CMAKE_COMMAND} -E copy
-    ${BINARY_DIR}/install/outputs/encrypted_provisioning_bundle.bin
-    "${CMAKE_BINARY_DIR}/secure_partition/encrypted_provisioning_bundle.bin"
-)
-
-add_dependencies(tfm-binaries tf-m-build)
-add_dependencies(tfm-ns-interface tfm-binaries)
-
 add_subdirectory(mqtt-agent-wrapper)
 add_subdirectory(provisioning provisioning_data)
 
@@ -264,65 +237,26 @@ if(${CMAKE_C_COMPILER_ID} STREQUAL "GNU")
             "-T" "${PRJ_DIR}/Bsp/an552_ns.ld"
             "--specs=nosys.specs"
     )
-    set(elf_to_bin_cmd ${GCC_ELF2BIN} -O binary ${CMAKE_CURRENT_BINARY_DIR}/aws-iot-example${CMAKE_EXECUTABLE_SUFFIX} ${CMAKE_CURRENT_BINARY_DIR}/aws-iot-example_unsigned.bin)
 else()
     target_link_options(aws-iot-example
         PRIVATE
             "--scatter=${PRJ_DIR}/Bsp/an552_ns.sct"
             "--map"
     )
-    set(elf_to_bin_cmd ${ARM_ELF2BIN} --bin --output ${CMAKE_CURRENT_BINARY_DIR}/aws-iot-example_unsigned.bin ${CMAKE_CURRENT_BINARY_DIR}/aws-iot-example${CMAKE_EXECUTABLE_SUFFIX} --bincombined)
 endif()
 
-add_custom_command(
-    TARGET
-        aws-iot-example
-    POST_BUILD
-    DEPENDS
-        ${CMAKE_CURRENT_BINARY_DIR}/aws-iot-example${CMAKE_EXECUTABLE_SUFFIX}
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/Middleware/ARM/TF-M/cmake)
+include(SignTfmImage)
 
-    BYPRODUCTS
-        ${CMAKE_CURRENT_BINARY_DIR}/aws-iot-example_unsigned.bin
-        ${CMAKE_CURRENT_BINARY_DIR}/aws-iot-example-update_signed.bin
-        ${CMAKE_CURRENT_BINARY_DIR}/aws-iot-example_signed.bin
+# The non-secure application image should be padded while being signed
+# Hence, passing "TRUE" as the input parameter to the pad option of sign function.
+iot_reference_arm_corstone3xx_tf_m_sign_image(aws-iot-example aws-iot-example_signed ${MCUBOOT_IMAGE_VERSION_NS} TRUE)
 
-    COMMAND
-        ${elf_to_bin_cmd}
-
-    COMMAND
-        python3 ${BINARY_DIR}/install/image_signing/scripts/wrapper/wrapper.py
-            -v ${MCUBOOT_IMAGE_VERSION_NS}
-            --layout ${BINARY_DIR}/install/image_signing/layout_files/signing_layout_ns.o
-            -k ${BINARY_DIR}/install/image_signing/keys/root-RSA-2048_1.pem
-            --public-key-format full
-            --align 1
-            --pad
-            --pad-header
-            -H 0x400
-            -s auto
-            --measured-boot-record
-            --confirm
-            ${CMAKE_CURRENT_BINARY_DIR}/aws-iot-example_unsigned.bin
-            ${CMAKE_CURRENT_BINARY_DIR}/aws-iot-example_signed.bin
-
-    COMMAND
-            # The update image is not padded to fill the whole slot (no --pad), because
-            # 1) the image to download is smaller without padding
-            # 2) the trailer that keeps track of boot and update statuses should not be overwritten
-            python3 ${BINARY_DIR}/install/image_signing/scripts/wrapper/wrapper.py
-                -v ${MCUBOOT_IMAGE_VERSION_NS_UPDATE}
-                --layout ${BINARY_DIR}/install/image_signing/layout_files/signing_layout_ns.o
-                -k ${BINARY_DIR}/install/image_signing/keys/root-RSA-2048_1.pem
-                --public-key-format full
-                --align 1
-                --pad-header
-                -H 0x400
-                -s auto
-                --measured-boot-record
-                --confirm
-                ${CMAKE_CURRENT_BINARY_DIR}/aws-iot-example_unsigned.bin
-                ${CMAKE_CURRENT_BINARY_DIR}/aws-iot-example-update_signed.bin
-)
+# The update image is not padded to fill the whole slot (no --pad), because
+# 1) the image to download is smaller without padding
+# 2) the trailer that keeps track of boot and update statuses should not be overwritten
+# Hence, passing "FALSE" as the input parameter for the pad option to the sign function.
+iot_reference_arm_corstone3xx_tf_m_sign_image(aws-iot-example aws-iot-example-update_signed ${MCUBOOT_IMAGE_VERSION_NS_UPDATE} FALSE)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/Middleware/AWS/cmake)
 include(GenerateAWSUpdateDigestAndSignature)

--- a/Projects/aws-iot-example/provisioning/CMakeLists.txt
+++ b/Projects/aws-iot-example/provisioning/CMakeLists.txt
@@ -41,16 +41,18 @@ if(${CMAKE_C_COMPILER_ID} STREQUAL "GNU")
             "-nostartfiles"
     )
     target_add_scatter_file(provisioning_data ${CMAKE_CURRENT_SOURCE_DIR}/provisioning_data.ld)
-    set(provisioning_elf_to_bin_cmd ${GCC_ELF2BIN} -O binary ${CMAKE_CURRENT_BINARY_DIR}/provisioning_data${CMAKE_EXECUTABLE_SUFFIX} ${CMAKE_CURRENT_BINARY_DIR}/provisioning_data.bin)
 else()
     target_add_scatter_file(provisioning_data ${CMAKE_CURRENT_SOURCE_DIR}/provisioning_data.sct)
-    set(provisioning_elf_to_bin_cmd ${ARM_ELF2BIN} --bin --output ${CMAKE_CURRENT_BINARY_DIR}/provisioning_data.bin ${CMAKE_CURRENT_BINARY_DIR}/provisioning_data${CMAKE_EXECUTABLE_SUFFIX} --bincombined)
 endif()
+
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/Tools/cmake)
+include(ConvertElfToBin)
 
 add_custom_command(OUTPUT provisioning_data.bin
     DEPENDS $<TARGET_FILE_DIR:provisioning_data>/provisioning_data${CMAKE_EXECUTABLE_SUFFIX}
-    COMMAND ${provisioning_elf_to_bin_cmd}
 )
+
+target_elf_to_bin(provisioning_data provisioning_data)
 
 add_custom_target(provisioning_data_bin ALL
     SOURCES provisioning_data.bin

--- a/Projects/blinky/CMakeLists.txt
+++ b/Projects/blinky/CMakeLists.txt
@@ -84,29 +84,6 @@ set( FREERTOS_PORT "GCC_ARM_CM55_TFM" CACHE STRING "" FORCE)
 
 add_subdirectory(../../Middleware/FreeRTOS ${CMAKE_BINARY_DIR}/Middleware/FreeRTOS)
 
-# Copy tf-m binaries at the root
-ExternalProject_Get_Property(tf-m-build BINARY_DIR)
-ExternalProject_Get_Property(tf-m-build SOURCE_DIR)
-
-add_custom_target(tfm-binaries
-  BYPRODUCTS
-    ${CMAKE_BINARY_DIR}/bootloader/bl2.axf
-    ${CMAKE_BINARY_DIR}/secure_partition/tfm_s.axf
-    ${CMAKE_BINARY_DIR}/secure_partition/tfm_s_unsigned.bin
-    ${CMAKE_BINARY_DIR}/secure_partition/tfm_s_signed.bin
-
-  COMMAND ${CMAKE_COMMAND} -E copy
-    ${BINARY_DIR}/install/outputs/bl2.axf
-    "${CMAKE_BINARY_DIR}/bootloader/bl2${CMAKE_EXECUTABLE_SUFFIX}"
-
-    COMMAND ${CMAKE_COMMAND} -E copy
-    ${BINARY_DIR}/install/outputs/tfm_s_signed.bin
-    "${CMAKE_BINARY_DIR}/secure_partition/tfm_s_signed.bin"
-)
-
-add_dependencies(tfm-binaries tf-m-build)
-add_dependencies(tfm-ns-interface tfm-binaries)
-
 # Declare the blinky executable
 add_executable(blinky main.c)
 
@@ -122,42 +99,17 @@ if(${CMAKE_C_COMPILER_ID} STREQUAL "GNU")
             "-T" "${PRJ_DIR}/Bsp/an552_ns.ld"
             "--specs=nosys.specs"
     )
-    set(elf_to_bin_cmd ${GCC_ELF2BIN} -O binary ${CMAKE_CURRENT_BINARY_DIR}/blinky${CMAKE_EXECUTABLE_SUFFIX} ${CMAKE_CURRENT_BINARY_DIR}/blinky_unsigned.bin)
 else()
     target_link_options(blinky
         PRIVATE
             "--scatter=${PRJ_DIR}/Bsp/an552_ns.sct"
             "--map"
     )
-    set(elf_to_bin_cmd ${ARM_ELF2BIN} --bin --output ${CMAKE_CURRENT_BINARY_DIR}/blinky_unsigned.bin ${CMAKE_CURRENT_BINARY_DIR}/blinky${CMAKE_EXECUTABLE_SUFFIX} --bincombined)
 endif()
 
-add_custom_command(
-    TARGET
-        blinky
-    POST_BUILD
-    DEPENDS
-        ${CMAKE_CURRENT_BINARY_DIR}/blinky${CMAKE_EXECUTABLE_SUFFIX}
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/Middleware/ARM/TF-M/cmake)
+include(SignTfmImage)
 
-    BYPRODUCTS
-        ${CMAKE_CURRENT_BINARY_DIR}/blinky_unsigned.bin
-        ${CMAKE_CURRENT_BINARY_DIR}/blinky_signed.bin
-
-    COMMAND
-        ${elf_to_bin_cmd}
-
-    COMMAND
-        python3 ${BINARY_DIR}/install/image_signing/scripts/wrapper/wrapper.py
-            -v 0.0.1
-            --layout ${BINARY_DIR}/install/image_signing/layout_files/signing_layout_ns.o
-            -k ${BINARY_DIR}/install/image_signing/keys/root-RSA-2048_1.pem
-            --public-key-format full
-            --align 1
-            --pad
-            --pad-header
-            -H 0x400
-            -s auto
-            --measured-boot-record
-            ${CMAKE_CURRENT_BINARY_DIR}/blinky_unsigned.bin
-            ${CMAKE_CURRENT_BINARY_DIR}/blinky_signed.bin
-)
+# The non-secure application image should be padded while being signed
+# Hence, passing "TRUE" as the input parameter to the pad option of sign function.
+iot_reference_arm_corstone3xx_tf_m_sign_image(blinky blinky_signed 0.0.1 TRUE)

--- a/Projects/blinky/CMakeLists.txt
+++ b/Projects/blinky/CMakeLists.txt
@@ -109,7 +109,14 @@ endif()
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/Middleware/ARM/TF-M/cmake)
 include(SignTfmImage)
+include(MergeTfmImages)
 
 # The non-secure application image should be padded while being signed
 # Hence, passing "TRUE" as the input parameter to the pad option of sign function.
 iot_reference_arm_corstone3xx_tf_m_sign_image(blinky blinky_signed 0.0.1 TRUE)
+
+# A user project that consumes the ARM FRI needs to explicitly provide
+# addresses in order to merge images for TF-M. The addresses cannot
+# be easily programmatically extracted as they are defined in the linker
+# scripts.
+iot_reference_arm_corstone3xx_tf_m_merge_images(blinky ${BL2_IMAGE_LOAD_ADDRESS} ${S_IMAGE_LOAD_ADDRESS} ${NS_IMAGE_LOAD_ADDRESS} ${S_PROVISIONING_BUNDLE_LOAD_ADDRESS})

--- a/Tools/cmake/ConvertElfToBin.cmake
+++ b/Tools/cmake/ConvertElfToBin.cmake
@@ -1,0 +1,24 @@
+# Copyright 2021-2023 Arm Limited and/or its affiliates
+# <open-source-office@arm.com>
+# SPDX-License-Identifier: MIT
+
+function(target_elf_to_bin target output_binary_name)
+    if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+        set(elf_to_bin arm-none-eabi-objcopy -O binary $<TARGET_FILE:${target}> $<TARGET_FILE_DIR:${target}>/${output_binary_name}.bin)
+    elseif(CMAKE_C_COMPILER_ID STREQUAL "ARMClang")
+        set(elf_to_bin fromelf --bin --output $<TARGET_FILE_DIR:${target}>/${output_binary_name}.bin $<TARGET_FILE:${target}>  --bincombined)
+    endif()
+
+    add_custom_command(
+        TARGET
+            ${target}
+        POST_BUILD
+        DEPENDS
+            $<TARGET_FILE:${target}>
+        COMMAND
+            ${elf_to_bin}
+        COMMAND
+            ${CMAKE_COMMAND} -E echo "-- built: $<TARGET_FILE_DIR:${target}>/${output_binary_name}.bin"
+        VERBATIM
+    )
+endfunction()

--- a/Tools/scripts/run.sh
+++ b/Tools/scripts/run.sh
@@ -59,20 +59,12 @@ done
 case "$TARGET" in
     corstone300 )
       FVP_BIN="VHT_Corstone_SSE-300_Ethos-U55"
-      FVP_S_IMAGE_LOAD_ADDRESS=0x11000000
-      FVP_NS_IMAGE_LOAD_ADDRESS=0x01060000
-      FVP_S_PROVISIONING_BUNDLE_LOAD_ADDRESS=0x10022000
-      FVP_NS_PROVISIONING_BUNDLE_LOAD_ADDRESS=0x210FF000
       ;;
     corstone310 )
       FVP_BIN="VHT_Corstone_SSE-310"
-      FVP_S_IMAGE_LOAD_ADDRESS=0x38000000
-      FVP_NS_IMAGE_LOAD_ADDRESS=0x28080000
-      FVP_S_PROVISIONING_BUNDLE_LOAD_ADDRESS=0x11022000
-      FVP_NS_PROVISIONING_BUNDLE_LOAD_ADDRESS=0x213FF000
       ;;
     *)
-      echo "Invalid target <Ccorstone300|corstone310>"
+      echo "Invalid target <Corstone300|corstone310>"
       show_usage
       exit 2
       ;;
@@ -81,11 +73,11 @@ esac
 case "$1" in
     blinky)
         EXAMPLE="$1"
-        FVP_IMAGE_OPTIONS="cpu0*="$BUILD_PATH/bootloader/bl2.axf" --data "$BUILD_PATH/secure_partition/tfm_s_signed.bin"@$FVP_S_IMAGE_LOAD_ADDRESS --data "$BUILD_PATH/Projects/$1/$1_signed.bin"@$FVP_NS_IMAGE_LOAD_ADDRESS --data "$BUILD_PATH/Middleware/ARM/TF-M/tf-m-build-prefix/src/tf-m-build-build/install/outputs/encrypted_provisioning_bundle.bin"@$FVP_S_PROVISIONING_BUNDLE_LOAD_ADDRESS"
+        MERGED_IMAGE_PATH="$BUILD_PATH/Projects/$EXAMPLE/blinky_merged.elf"
         ;;
     aws-iot-example)
         EXAMPLE="$1"
-        FVP_IMAGE_OPTIONS="cpu0*="$BUILD_PATH/bootloader/bl2.axf" --data "$BUILD_PATH/secure_partition/tfm_s_signed.bin"@$FVP_S_IMAGE_LOAD_ADDRESS --data "$BUILD_PATH/Projects/$1/$1_signed.bin"@$FVP_NS_IMAGE_LOAD_ADDRESS --data "$BUILD_PATH/Projects/$EXAMPLE/provisioning_data/provisioning_data.bin"@$FVP_NS_PROVISIONING_BUNDLE_LOAD_ADDRESS --data "$BUILD_PATH/Middleware/ARM/TF-M/tf-m-build-prefix/src/tf-m-build-build/install/outputs/encrypted_provisioning_bundle.bin"@$FVP_S_PROVISIONING_BUNDLE_LOAD_ADDRESS"
+        MERGED_IMAGE_PATH="$BUILD_PATH/Projects/$EXAMPLE/aws-iot-example_merged.elf"
         ;;
     *)
         echo "Usage: $0 <blinky,aws-iot-example>" >&2
@@ -96,4 +88,4 @@ esac
 OPTIONS="-C mps3_board.visualisation.disable-visualisation=1 -C mps3_board.smsc_91c111.enabled=1 -C mps3_board.hostbridge.userNetworking=1 -C mps3_board.telnetterminal0.start_telnet=0 -C mps3_board.uart0.out_file="-"  -C mps3_board.uart0.unbuffered_output=1 --stat  -C mps3_board.DISABLE_GATING=1"
 
 # Start the FVP
-$FVP_BIN $OPTIONS -a $FVP_IMAGE_OPTIONS
+$FVP_BIN $OPTIONS -a $MERGED_IMAGE_PATH

--- a/conftest.py
+++ b/conftest.py
@@ -61,11 +61,7 @@ def fvp(fvp_path, build_path, vsi_script_path, fvp_options):
     # Note: It can take few seconds to terminate the FVP
     cmdline = [
         fvp_path,
-        "-a", f"cpu0*={build_path}/bootloader/bl2.axf",
-        "--data", f"{build_path}/secure_partition/tfm_s_signed.bin@0x11000000",
-        "--data", f"{build_path}/Projects/aws-iot-example/aws-iot-example_signed.bin@0x01060000",
-        "--data", f"{build_path}/Projects/aws-iot-example/provisioning_data/provisioning_data.bin@0x210FF000",
-        "--data", f"{build_path}/secure_partition/encrypted_provisioning_bundle.bin@0x10022000",
+        "-a", f"{build_path}/Projects/aws-iot-example/aws-iot-example_merged.elf",
         "-C", "core_clk.mul=200000000",
         "-C", "mps3_board.visualisation.disable-visualisation=1",
         "-C", "mps3_board.telnetterminal0.start_telnet=0",


### PR DESCRIPTION
<!--- Title -->

Description
-----------
* SignTfmImage.cmake is introduced to add the needed sign function to be used to sign the non-secure (application) binaries.
* MergeTfmImages.cmake is introduced to be used to merge Bootloader, TF-M secure, Non-secure user application, secure and non-secure provisioning images into one image to be loaded inside the ROM rather than loading different images at their respective addresses.
* These change enhance re-usability and decrease code duplication within the existing applications and applications to be added.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
