### PR TITLE
Uncrustify: use replace option

### DIFF
--- a/Tools/scripts/run_uncrustify.sh
+++ b/Tools/scripts/run_uncrustify.sh
@@ -4,4 +4,6 @@
 # <open-source-office@arm.com>
 # SPDX-License-Identifier: MIT
 
-find Projects Config -iname "*.[hc]" -exec uncrustify --check -c Tools/uncrustify.cfg {} +
+git submodule deinit --all -f
+find . -iname "*.[hc]" -exec uncrustify --replace --no-backup --if-changed -c Tools/uncrustify.cfg -l C {} +
+git submodule update --init --recursive

--- a/Tools/uncrustify.cfg
+++ b/Tools/uncrustify.cfg
@@ -1,7 +1,25 @@
-# Copyright (c) 2023 Arm Limited and/or its affiliates
-# <open-source-office@arm.com>
-# SPDX-License-Identifier: MIT
 # Uncrustify-0.69.0
+# Copyright (C) 2023 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+# http://aws.amazon.com/freertos
+# http://www.FreeRTOS.org
 
 newlines                        = auto     # lf/crlf/cr/auto
 input_tab_size                  = 4        # unsigned number

--- a/release_changes/202311150923.change
+++ b/release_changes/202311150923.change
@@ -1,0 +1,1 @@
+uncrustify: Use replace option for correcting findings.


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
The --check option was used to check for uncrustify failures, it is better to use --replace instead of --check as it corrects the failures beside doing what --check does. Developers can benefit from this improvement when they run the pre-commit locally.

Uncrustify should check for all the FRI project files except for those that are downloaded with git submodule, to do so, we have to de-init all the submodules before Uncrustify tool run and then initialise them back right after it finish.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
