### PR TITLE
bsp: synchronize serial access

### DIFF
--- a/bsp/CMakeLists.txt
+++ b/bsp/CMakeLists.txt
@@ -65,4 +65,5 @@ target_include_directories(fri-bsp
 target_link_libraries(fri-bsp
     PUBLIC
         arm-corstone-platform-bsp
+        freertos_kernel
 )

--- a/release_changes/202401041514.change
+++ b/release_changes/202401041514.change
@@ -1,0 +1,1 @@
+serial: Fix multithread synchronisation


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
The serial driver is used by multiple tasks and not all tasks use the Log APIs to send data to the serial driver.

This was causing serial data buffer corruption.

Synchronise the access of the serial driver using mutual exclusion to make it thread-safe.

This also removes code duplication and fixes return values for
the write system call:
* Arm GNU Toolchain: On failure, `-1`.
                        On success, total chars written.
* Arm Compiler: On failure, a positive number representing the number of
                chars NOT written or a negative number indicating an error.
                On success, `0`.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
