### PR TITLE
build: Add optional argument for build directory path specification

### DIFF
--- a/release_changes/202401091359.change
+++ b/release_changes/202401091359.change
@@ -1,0 +1,1 @@
+build: Add custom build directory option

--- a/tools/scripts/build.sh
+++ b/tools/scripts/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2023 Arm Limited and/or its affiliates
+# Copyright 2023-2024 Arm Limited and/or its affiliates
 # <open-source-office@arm.com>
 # SPDX-License-Identifier: MIT
 
@@ -66,10 +66,11 @@ function show_usage {
     cat <<EOF
 Usage: $0 [options] example
 
-Download dependencies, apply patches and build an example.
+Apply patches and build an example.
 
 Options:
     -h,--help                   Show this help
+    -p,--path                   Path to the build directory
     -c,--clean                  Clean build
     -t,--target                 Build target (corstone300 or corstone310)
     --toolchain                 Compiler (GNU or ARMCLANG)
@@ -87,8 +88,8 @@ if [[ $# -eq 0 ]]; then
     exit 1
 fi
 
-SHORT=t:,c,h,q
-LONG=target:,toolchain:,clean,help,configure-only,certificate_path:,private_key_path:,integration-tests
+SHORT=t:,c,h,q,p:
+LONG=target:,toolchain:,clean,help,configure-only,certificate_path:,private_key_path:,integration-tests:,path:
 OPTS=$(getopt -n build --options $SHORT --longoptions $LONG -- "$@")
 
 eval set -- "$OPTS"
@@ -103,6 +104,10 @@ do
     -c | --clean )
       CLEAN=1
       shift
+      ;;
+    -p | --path )
+      BUILD_PATH=$2
+      shift 2
       ;;
     -t | --target )
       TARGET=$2

--- a/tools/scripts/run.sh
+++ b/tools/scripts/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2023 Arm Limited and/or its affiliates
+# Copyright 2023-2024 Arm Limited and/or its affiliates
 # <open-source-office@arm.com>
 # SPDX-License-Identifier: MIT
 
@@ -31,8 +31,8 @@ Examples:
 EOF
 }
 
-SHORT=t:,f:,h
-LONG=target:,fvp_type:,help
+SHORT=t:,f:,h,p:
+LONG=target:,fvp_type:,help,path:
 OPTS=$(getopt -n run --options $SHORT --longoptions $LONG -- "$@")
 
 eval set -- "$OPTS"
@@ -43,6 +43,10 @@ do
     -h | --help )
       show_usage
       exit 0
+      ;;
+    -p | --path )
+      BUILD_PATH=$2
+      shift 2
       ;;
     -t | --target )
       TARGET=$2


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
The additional optional argument is useful to allow the end user to create multiple build directories
for various applications and/or variants.


Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
