### PR TITLE
build: Do not require certificate and key for Blinky

### DIFF
--- a/release_changes/202401111515.change
+++ b/release_changes/202401111515.change
@@ -1,0 +1,2 @@
+
+build: Do not require certificate and key for Blinky

--- a/tools/scripts/build.sh
+++ b/tools/scripts/build.sh
@@ -189,13 +189,13 @@ case "$TOOLCHAIN" in
       ;;
 esac
 
-if [ ! -f "$CERTIFICATE_PATH" ]; then
+if [ "$EXAMPLE" != "blinky" ] && [ ! -f "$CERTIFICATE_PATH" ]; then
     echo "The --certificate_path must be set to an existing file."
     show_usage
     exit 2
 fi
 
-if [ ! -f "$PRIVATE_KEY_PATH" ]; then
+if [ "$EXAMPLE" != "blinky" ] && [ ! -f "$PRIVATE_KEY_PATH" ]; then
     echo "The --private_key_path must be set to an existing file."
     show_usage
     exit 2


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
Allow Blinky app to be built without setting certificates

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
