### PR TITLE
patches: Use robust patches function to fix corstone300's hardfault

### DIFF
--- a/components/ai/ml_embedded_evaluation_kit/CMakeLists.txt
+++ b/components/ai/ml_embedded_evaluation_kit/CMakeLists.txt
@@ -8,32 +8,15 @@ set(ml_embedded_evaluation_kit_SOURCE_DIR
     "Path to ML Embedded Evaluation Kit source code"
 )
 
-execute_process(COMMAND git am --abort
-    COMMAND git am ${CMAKE_CURRENT_LIST_DIR}/integration/patches/0001-resources-Replace-model-wav2letter-with-tiny_wav2let.patch
-    WORKING_DIRECTORY ${ml_embedded_evaluation_kit_SOURCE_DIR}
-    OUTPUT_QUIET
-    ERROR_QUIET
-)
+include(ApplyPatches)
 
-execute_process(COMMAND git am --abort
-    COMMAND git am ${CMAKE_CURRENT_LIST_DIR}/integration/patches/0001-toolchain-Fix-Arm-GNU-Toolchain-13.2-Rel1-compatibil.patch
-    WORKING_DIRECTORY ${ml_embedded_evaluation_kit_SOURCE_DIR}
-    OUTPUT_QUIET
-    ERROR_QUIET
+set(PATCH_FILES_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/integration/patches")
+set(PATCH_FILES
+    "${PATCH_FILES_DIRECTORY}/0001-asm-syntax-Replace-incorrect-type-specifier.patch"
+    "${PATCH_FILES_DIRECTORY}/0001-platform-drivers-Remove-RTE_components-header-file.patch"
+    "${PATCH_FILES_DIRECTORY}/0001-resources-Replace-model-wav2letter-with-tiny_wav2let.patch"
+    "${PATCH_FILES_DIRECTORY}/0001-toolchain-Fix-Arm-GNU-Toolchain-13.2-Rel1-compatibil.patch"
 )
-
-execute_process(COMMAND git am --abort
-    COMMAND git am ${CMAKE_CURRENT_LIST_DIR}/integration/patches/0001-platform-drivers-Remove-RTE_components-header-file.patch
-    WORKING_DIRECTORY ${ml_embedded_evaluation_kit_SOURCE_DIR}
-    OUTPUT_QUIET
-    ERROR_QUIET
-)
-
-execute_process(COMMAND git am --abort
-    COMMAND git am ${CMAKE_CURRENT_LIST_DIR}/integration/patches/0001-asm-syntax-Replace-incorrect-type-specifier.patch
-    WORKING_DIRECTORY ${ml_embedded_evaluation_kit_SOURCE_DIR}
-    OUTPUT_QUIET
-    ERROR_QUIET
-)
+iot_reference_arm_corstone3xx_apply_patches("${ml_embedded_evaluation_kit_SOURCE_DIR}" "${PATCH_FILES}")
 
 add_subdirectory(integration)

--- a/components/aws_iot/corepkcs11/CMakeLists.txt
+++ b/components/aws_iot/corepkcs11/CMakeLists.txt
@@ -8,11 +8,10 @@ set(corepkcs11_SOURCE_DIR
     "Path to corePKCS11 source code"
 )
 
-execute_process(COMMAND git am --abort
-    COMMAND git am ${CMAKE_CURRENT_SOURCE_DIR}/integration/patches/0001-Do-not-define-__PASTE-macro-for-Arm-compiler.patch
-    WORKING_DIRECTORY ${corepkcs11_SOURCE_DIR}
-    OUTPUT_QUIET
-    ERROR_QUIET
-)
+include(ApplyPatches)
+
+set(PATCH_FILES_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/integration/patches")
+set(PATCH_FILES "${PATCH_FILES_DIRECTORY}/0001-Do-not-define-__PASTE-macro-for-Arm-compiler.patch")
+iot_reference_arm_corstone3xx_apply_patches("${corepkcs11_SOURCE_DIR}" "${PATCH_FILES}")
 
 add_subdirectory(integration)

--- a/components/aws_iot/ota_for_aws_iot_embedded_sdk/CMakeLists.txt
+++ b/components/aws_iot/ota_for_aws_iot_embedded_sdk/CMakeLists.txt
@@ -8,11 +8,10 @@ set(ota_for_aws_iot_embedded_sdk_SOURCE_DIR
     "Path to AWS IoT Over-the-air Update source code"
 )
 
-execute_process(COMMAND git am --abort
-    COMMAND git am ${CMAKE_CURRENT_SOURCE_DIR}/integration/patches/0001-Add-non-constant-appFirmwareVersion-extern.patch
-    WORKING_DIRECTORY ${ota_for_aws_iot_embedded_sdk_SOURCE_DIR}
-    OUTPUT_QUIET
-    ERROR_QUIET
-)
+include(ApplyPatches)
+
+set(PATCH_FILES_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/integration/patches")
+set(PATCH_FILES "${PATCH_FILES_DIRECTORY}/0001-Add-non-constant-appFirmwareVersion-extern.patch")
+iot_reference_arm_corstone3xx_apply_patches("${ota_for_aws_iot_embedded_sdk_SOURCE_DIR}" "${PATCH_FILES}")
 
 add_subdirectory(integration)

--- a/components/connectivity/iot_vsocket/CMakeLists.txt
+++ b/components/connectivity/iot_vsocket/CMakeLists.txt
@@ -8,11 +8,10 @@ set(iot_vsocket_SOURCE_DIR
     "Path to Arm Virtual Hardware - IoT Virtual Socket source code"
 )
 
-execute_process(COMMAND git am --abort
-    COMMAND git am ${CMAKE_CURRENT_LIST_DIR}/integration/patches/0001-Replace-CMSIS-RTX-APIs-with-FreeRTOS-APIs.patch
-    WORKING_DIRECTORY ${iot_vsocket_SOURCE_DIR}
-    OUTPUT_QUIET
-    ERROR_QUIET
-)
+include(ApplyPatches)
+
+set(PATCH_FILES_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/integration/patches")
+set(PATCH_FILES "${PATCH_FILES_DIRECTORY}/0001-Replace-CMSIS-RTX-APIs-with-FreeRTOS-APIs.patch")
+iot_reference_arm_corstone3xx_apply_patches("${iot_vsocket_SOURCE_DIR}" "${PATCH_FILES}")
 
 add_subdirectory(integration)

--- a/components/security/trusted_firmware-m/CMakeLists.txt
+++ b/components/security/trusted_firmware-m/CMakeLists.txt
@@ -8,11 +8,10 @@ set(trusted_firmware-m_SOURCE_DIR
     "Path to Trusted Firmware-M source code"
 )
 
-execute_process(COMMAND git am --abort
-    COMMAND git am ${CMAKE_CURRENT_LIST_DIR}/integration/patches/0001-corstone300-Modify-ISRAM0-to-be-non-secure-partition.patch
-    WORKING_DIRECTORY ${trusted_firmware-m_SOURCE_DIR}
-    OUTPUT_QUIET
-    ERROR_QUIET
-)
+include(ApplyPatches)
+
+set(PATCH_FILES_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/integration/patches")
+set(PATCH_FILES "${PATCH_FILES_DIRECTORY}/0001-corstone300-Modify-ISRAM0-to-be-non-secure-partition.patch")
+iot_reference_arm_corstone3xx_apply_patches("${trusted_firmware-m_SOURCE_DIR}" "${PATCH_FILES}")
 
 add_subdirectory(integration)

--- a/docs/project_organisation.md
+++ b/docs/project_organisation.md
@@ -137,12 +137,15 @@ set(coremqtt_agent_SOURCE_DIR
     "Path to coreMQTT-Agent source code"
 )
 
-execute_process(COMMAND git am --abort
-    COMMAND git am ${CMAKE_CURRENT_SOURCE_DIR}/integration/patches/0001-This-patch-is-to-be-applied-to-the-library.patch
-    WORKING_DIRECTORY ${coremqtt_agent_SOURCE_DIR}
-    OUTPUT_QUIET
-    ERROR_QUIET
+include(ApplyPatches)
+
+set(PATCH_FILES_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/integration/patches")
+set(PATCH_FILES
+    "${PATCH_FILES_DIRECTORY}/0001-This-patch-is-to-be-applied-to-the-library.patch"
+    "${PATCH_FILES_DIRECTORY}/0002-This-patch-is-to-be-applied-to-the-library.patch"
+    "${PATCH_FILES_DIRECTORY}/000n-This-patch-is-to-be-applied-to-the-library.patch"
 )
+iot_reference_arm_corstone3xx_apply_patches("${coremqtt_agent_SOURCE_DIR}" "${PATCH_FILES}")
 
 add_subdirectory(integration)
 ```

--- a/release_changes/202401301136.change
+++ b/release_changes/202401301136.change
@@ -1,0 +1,1 @@
+patches: Use robust patches function to fix corstone300's hardfault.

--- a/tools/cmake/ApplyPatches.cmake
+++ b/tools/cmake/ApplyPatches.cmake
@@ -1,0 +1,113 @@
+#-------------------------------------------------------------------------------
+# Copyright (c) 2022 Cypress Semiconductor Corporation (an Infineon company)
+# or an affiliate of Cypress Semiconductor Corporation. All rights reserved.
+# Copyright (c) 2023-2024 Arm Limited. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Based on: https://git.trustedfirmware.org/TF-M/trusted-firmware-m.git/tree/cmake/remote_library.cmake?ef726cb3f25e8762182755104c367567b2387d59
+#
+#-------------------------------------------------------------------------------
+
+find_package(Git)
+
+# This function applies patches if they are not applied yet.
+# It assumes that patches have not been applied if it's not possible to revert them.
+#
+# WORKING_DIRECTORY - working directory where patches should be applied.
+# PATCH_FILES - list of patches. Patches will be applied in alphabetical order.
+function(iot_reference_arm_corstone3xx_apply_patches WORKING_DIRECTORY PATCH_FILES)
+    # Validate if patches are already applied by reverting patches in reverse order
+    # Step 1 - keep changes in stash with random message/name to detect
+    # that stash has been created by git
+    string(RANDOM LENGTH 16 STASH_NAME)
+    set(STASH_NAME "fri-apply_patches-${STASH_NAME}")
+    execute_process(COMMAND "${GIT_EXECUTABLE}" stash push -u -m "${STASH_NAME}"
+        WORKING_DIRECTORY ${WORKING_DIRECTORY}
+        RESULT_VARIABLE VALIDATION_STATUS
+        ERROR_QUIET OUTPUT_QUIET
+    )
+    # Step 2 - get list of stashes to validate that stash has been created
+    if (VALIDATION_STATUS EQUAL 0)
+        execute_process(COMMAND "${GIT_EXECUTABLE}" stash list
+            WORKING_DIRECTORY ${WORKING_DIRECTORY}
+            OUTPUT_VARIABLE STASH_LIST
+            RESULT_VARIABLE VALIDATION_STATUS
+            ERROR_QUIET
+        )
+        # Look for stash message to detect stash creation
+        string(FIND "${STASH_LIST}" "${STASH_NAME}" STASH_INDEX)
+        if (STASH_INDEX LESS 0)
+            # Stash is not created, most probably because there is no changes
+            set(VALIDATION_STATUS 0)
+        else()
+            # Step 3 - restore changes with git stash apply
+            if (VALIDATION_STATUS EQUAL 0)
+                execute_process(COMMAND "${GIT_EXECUTABLE}" stash apply
+                    WORKING_DIRECTORY ${WORKING_DIRECTORY}
+                    RESULT_VARIABLE VALIDATION_STATUS
+                    ERROR_QUIET OUTPUT_QUIET
+                )
+            endif()
+        endif()
+    endif()
+    # Step 4 - revert patches in reverse order
+    if (VALIDATION_STATUS EQUAL 0)
+        # Sort list of patches in descending order for validation
+        list(SORT PATCH_FILES ORDER DESCENDING)
+        foreach(PATCH ${PATCH_FILES})
+            execute_process(COMMAND "${GIT_EXECUTABLE}" apply --reverse --verbose "${PATCH}"
+                WORKING_DIRECTORY ${WORKING_DIRECTORY}
+                RESULT_VARIABLE VALIDATION_STATUS
+                ERROR_QUIET OUTPUT_QUIET
+            )
+            if (NOT VALIDATION_STATUS EQUAL 0)
+                # patch failed to be applied, assume that we need to restore and
+                # apply all patch set
+                break()
+            endif()
+        endforeach()
+    endif()
+    # Step 5 - pop stash to restore original state
+    if (STASH_INDEX GREATER_EQUAL 0)
+        # Clear index before restore
+        execute_process(COMMAND "${GIT_EXECUTABLE}" clean -df
+            WORKING_DIRECTORY ${WORKING_DIRECTORY}
+            ERROR_QUIET OUTPUT_QUIET
+        )
+        execute_process(COMMAND "${GIT_EXECUTABLE}" reset --hard
+            WORKING_DIRECTORY ${WORKING_DIRECTORY}
+            ERROR_QUIET OUTPUT_QUIET
+        )
+        execute_process(COMMAND "${GIT_EXECUTABLE}" stash pop --index
+            WORKING_DIRECTORY ${WORKING_DIRECTORY}
+            ERROR_QUIET OUTPUT_QUIET
+        )
+    else()
+        # There is no stash, restore commit by clearing index
+        execute_process(COMMAND "${GIT_EXECUTABLE}" clean -df
+            WORKING_DIRECTORY ${WORKING_DIRECTORY}
+            ERROR_QUIET OUTPUT_QUIET
+        )
+        execute_process(COMMAND "${GIT_EXECUTABLE}" reset --hard
+            WORKING_DIRECTORY ${WORKING_DIRECTORY}
+            ERROR_QUIET OUTPUT_QUIET
+        )
+    endif()
+
+    if (NOT VALIDATION_STATUS EQUAL 0)
+        # Validation has been failed, so we assume that patches should be applied
+        # Sort list of patches in ascending order
+        list(SORT PATCH_FILES ORDER ASCENDING)
+
+        set(EXECUTE_COMMAND "${GIT_EXECUTABLE}" apply --verbose ${PATCH_FILES})
+        execute_process(COMMAND ${EXECUTE_COMMAND}
+            WORKING_DIRECTORY ${WORKING_DIRECTORY}
+            RESULT_VARIABLE PATCH_STATUS
+            COMMAND_ECHO STDOUT
+        )
+        if (NOT PATCH_STATUS EQUAL 0)
+            message( FATAL_ERROR "Failed to apply patches at ${WORKING_DIRECTORY}" )
+        endif()
+    endif()
+endfunction()


### PR DESCRIPTION
This new way of applying patches is added to fix Corstone300 platform hardfault exception happening as the TF-M patch
(components/security/trusted_firmware-m/integration/patches /0001-corstone300-Modify-ISRAM0-to-be-non-secure-partition.patch) for this platform is sometimes not applied.

Patches are now applied using `git stash` and
`git apply`. This methodology is much better as
it reports whenever the new CMake function fails
to apply a certain patch.

Note:

This solution is based on what TF-M implemented in `components/security/trusted_firmware-m/library/cmake/ remote_library.cmake`

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
