### PR TITLE
integration-app: Reduce binary code size with debug experience

### DIFF
--- a/applications/freertos_iot_libraries_tests/CMakeLists.txt
+++ b/applications/freertos_iot_libraries_tests/CMakeLists.txt
@@ -69,6 +69,14 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 project(freertos-iot-libraries-tests LANGUAGES C)
 
 set(CMAKE_EXECUTABLE_SUFFIX ".axf")
+
+# Set global optimization level to reduce code size while keeping the debug experience.
+if(${CMAKE_C_COMPILER_ID} STREQUAL "GNU")
+    add_compile_options(-Og)
+elseif(${CMAKE_C_COMPILER_ID} STREQUAL "ARMClang")
+    add_compile_options(-O1)
+endif()
+
 # This variable is checked to apply configurations specific to FreeRTOS Libraries Integrations Tests
 set(FREERTOS_LIBRARIES_INTEGRATION_TESTS 1)
 

--- a/applications/freertos_iot_libraries_tests/test_param_config.h
+++ b/applications/freertos_iot_libraries_tests/test_param_config.h
@@ -70,7 +70,7 @@
  * PUBLISH message and ack responses for QoS 1 and QoS 2 communications
  * with the broker.
  */
-#define MQTT_TEST_PROCESS_LOOP_TIMEOUT_MS    ( 40000 )
+#define MQTT_TEST_PROCESS_LOOP_TIMEOUT_MS    ( 54630 )
 
 /**
  * @brief Root certificate of the IoT Core.

--- a/release_changes/202402131559.change
+++ b/release_changes/202402131559.change
@@ -1,0 +1,1 @@
+integration-app: Reduce binary code size with debug experience


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->

Change the optimization level for the `freertos-iot-libraries-tests` application to reduce code size whilst still maintaining a comfortable debugging experience.

Arm Compiler For Embedded optimization level is set to use `-O1` and Arm GNU Toolchain is set to use `-Og`.
These optimization levels are already used by the other FRI applications.

The Arm Compiler For Embedded `-O1` optimization level results in a slower binary execution speed on `FVP_Corstone_SSE-310`. The MQTT test process loop timeout period
(`MQTT_TEST_PROCESS_LOOP_TIMEOUT_MS`) needs therefore to be increased from `40000` to `54630` to pass the
`MqttTest, MQTT_Restore_Session_Duplicate_Incoming_Publish_Qos1` test case.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
