### PR TITLE
build: Resolve certificate and key paths

### DIFF
--- a/release_changes/202401221030.change
+++ b/release_changes/202401221030.change
@@ -1,0 +1,1 @@
+build: Resolve certificate and key paths.

--- a/tools/scripts/build.sh
+++ b/tools/scripts/build.sh
@@ -82,8 +82,8 @@ Options:
     --toolchain                 Compiler (GNU or ARMCLANG)
     -q, --integration-tests     Build FreeRTOS integration tests
     --configure-only Create build tree but do not build
-    --certificate_path          The full path for the AWS device certificate
-    --private_key_path          The full path for the AWS device private key
+    --certificate_path          Path to the AWS device certificate
+    --private_key_path          Path to the AWS device private key
 Examples:
     blinky, aws-iot-example, keyword-detection, speech-recognition
 EOF
@@ -132,11 +132,11 @@ do
       shift 2
       ;;
     --certificate_path )
-      CERTIFICATE_PATH=$2
+      CERTIFICATE_PATH=$(realpath "$2")
       shift 2
       ;;
     --private_key_path )
-      PRIVATE_KEY_PATH=$2
+      PRIVATE_KEY_PATH=$(realpath "$2")
       shift 2
       ;;
     -q | --integration-tests )


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
Since both the certificate path and the private key path are forwarded to CMake, the user is asked to specify them as absolute. Build process fails when either of these is a local path instead. Unfortunately, although our build script checks for existence of both files, the check is not done from CMake's point of view. As a result, the build error seen by the user is hard to understand (no known rule to make a missing ninja target).

Resolve both AWS certificate path and AWS private key path to prevent the unhelpful error message from showing up, and make the build script more flexible by giving users option to use local paths as well as absolute paths for PEM files.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
