### PR TITLE
build: Fix missing executable suffix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,9 +12,9 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "Release" CACHE STRING "The build type" FORCE)
 endif()
 
-set(CMAKE_EXECUTABLE_SUFFIX ".axf")
+set(CMAKE_EXECUTABLE_SUFFIX ".axf" PARENT_SCOPE)
 
-set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON PARENT_SCOPE)
 
 add_subdirectory(bsp)
 add_subdirectory(components EXCLUDE_FROM_ALL)


### PR DESCRIPTION
build: Fix missing executable suffix

Description
-----------
Add missing PARENT_SCOPE to root folder CMakeLists.txt. It is needed as the entry point is the application/<example>.

Test Steps
-----------
All platforms are tested with all the examples. The resulting application files are manually verified to have to correct suffix.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
