### PR TITLE
ml-apps: Fix building different ML apps subsequently

### DIFF
--- a/components/ai/ml_embedded_evaluation_kit/CMakeLists.txt
+++ b/components/ai/ml_embedded_evaluation_kit/CMakeLists.txt
@@ -12,7 +12,7 @@ include(ApplyPatches)
 
 set(PATCH_FILES_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/integration/patches")
 set(PATCH_FILES
-    "${PATCH_FILES_DIRECTORY}/0001-use-case-resources-Enabled-user-provided-metadata.patch"
+    "${PATCH_FILES_DIRECTORY}/0001-use-case-resources-User-selectable-model-resources.patch"
     "${PATCH_FILES_DIRECTORY}/0002-Use-CMSIS_device_header-instead-of-RTE_Components.h.patch"
     "${PATCH_FILES_DIRECTORY}/0003-Make-ETHOSU_ARCH-configurable-in-TensorFlow-CMake.patch"
     "${PATCH_FILES_DIRECTORY}/0004-Move-activation_buf_dram-to-.bss.NoInit-region.patch"

--- a/components/ai/ml_embedded_evaluation_kit/integration/cmake/ConvertAudioSourceToCode.cmake
+++ b/components/ai/ml_embedded_evaluation_kit/integration/cmake/ConvertAudioSourceToCode.cmake
@@ -11,7 +11,7 @@ function(iot_reference_arm_corstone3xx_convert_audio_source_to_code audio_path g
         # use ml-embedded-evaluation-kit's Python Virtual Environment which
         # contains dependencies for gen_audio_cpp.py
         COMMAND bash -c " \
-            source ${ml_embedded_evaluation_kit_SOURCE_DIR}/resources_downloaded/env/bin/activate && \
+            source ${CMAKE_CURRENT_BINARY_DIR}/mlek_resources_downloaded/env/bin/activate && \
             python3 ${ml_embedded_evaluation_kit_SOURCE_DIR}/scripts/py/gen_audio_cpp.py \
             --audio_path ${audio_path} \
             --source_folder_path ${generated_path} \

--- a/components/ai/ml_embedded_evaluation_kit/integration/cmake/SetupMlEmbeddedEvaluationKitLibraries.cmake
+++ b/components/ai/ml_embedded_evaluation_kit/integration/cmake/SetupMlEmbeddedEvaluationKitLibraries.cmake
@@ -18,10 +18,13 @@ set(CMSIS_NN_SRC_PATH           "${ml_embedded_evaluation_kit_SOURCE_DIR}/depend
 set(TENSORFLOW_SRC_PATH         "${ml_embedded_evaluation_kit_SOURCE_DIR}/dependencies/tensorflow")
 set(ETHOS_U_NPU_DRIVER_SRC_PATH "${ml_embedded_evaluation_kit_SOURCE_DIR}/dependencies/core-driver")
 
+set(RESOURCES_DIR       ${CMAKE_CURRENT_BINARY_DIR}/mlek_resources_downloaded)
+
 # Extra arguments for setting up default resources (for vela optimizer)
 set(ML_RESOURCES_SET_UP_ARGS
     "--additional-ethos-u-config-name=${ETHOSU_TARGET_NPU_CONFIG}"
     "--use-case-resources-file=${ML_USE_CASE_RESOURCES_FILE}"
+    "--downloaded-model-resources-path=${RESOURCES_DIR}"
 )
 
 # Tensorflow settings
@@ -33,7 +36,9 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tensorflow-microlite)
 # Set up default resources. This downloads the TF-Lite models and optimizes them for the target
 # Note: This step is using pip install in its venv setup, which involves installing Vela compiler.
 #       If it is not already installed, it will use CC to compile it to the host machine, but the toolchain file overwrites the CC env.
-set(RESOURCES_OUTFILE "${ml_embedded_evaluation_kit_SOURCE_DIR}/resources_downloaded/resources_downloaded_metadata.json")
+set(RESOURCES_OUTFILE "${RESOURCES_DIR}/resources_downloaded_metadata.json")
+
+# Do not re-download the resources if they have already been downloaded
 if(NOT EXISTS "${RESOURCES_OUTFILE}")
     execute_process(
         COMMAND
@@ -51,7 +56,6 @@ endif()
 # Setup virtualenv (done by setup_source_generator())
 set(CMAKE_SCRIPTS_DIR   ${ml_embedded_evaluation_kit_SOURCE_DIR}/scripts/cmake)
 include(${CMAKE_SCRIPTS_DIR}/source_gen_utils.cmake)
-set(RESOURCES_DIR       ${ml_embedded_evaluation_kit_SOURCE_DIR}/resources_downloaded)
 set(SCRIPTS_DIR         ${ml_embedded_evaluation_kit_SOURCE_DIR}/scripts)
 setup_source_generator()
 

--- a/components/ai/ml_embedded_evaluation_kit/integration/patches/0001-use-case-resources-User-selectable-model-resources.patch
+++ b/components/ai/ml_embedded_evaluation_kit/integration/patches/0001-use-case-resources-User-selectable-model-resources.patch
@@ -1,9 +1,9 @@
-From f3f30b50769f5c3cf3c32f1b715acefd6ba0b8bc Mon Sep 17 00:00:00 2001
-From: Hugues Kamba-Mpiana <hugues.kambampiana@arm.com>
-Date: Mon, 4 Mar 2024 16:01:55 +0000
-Subject: [PATCH] use-case-resources: Enabled user provided metadata
+From 37e11fb6a28f9de8b0d0be9ad595f0f6a91ca2c4 Mon Sep 17 00:00:00 2001
+From: Hugues Kamba Mpiana <hugues.kambampiana@arm.com>
+Date: Tue, 12 Mar 2024 15:49:00 +0000
+Subject: [PATCH] use-case-resources: User selectable model resources
 
-An optional argument has been added to the `set_up_default_resources.py`
+An optional argument is added to the `set_up_default_resources.py`
 Python script to allow passing of a user defined use case resources
 metadata JSON file.
 This shortens the build time by only downloading the resources the
@@ -11,14 +11,18 @@ end user is interested in. It also shortens the optimization part
 which takes additional minutes as it is done for all models and for
 all the specified NPU configurations.
 
+In addition, the location of the downloaded resources can be specified
+to allow users to place them wherever they require. Such location
+can be a build directory so they can be deleted whenever a clean build
+is required if different model resources need to be downloaded.
 
-Signed-off-by: Hugues Kamba-Mpiana <hugues.kambampiana@arm.com>
+Signed-off-by: Hugues Kamba Mpiana <hugues.kambampiana@arm.com>
 ---
- set_up_default_resources.py | 23 ++++++++++++++++++-----
- 1 file changed, 18 insertions(+), 5 deletions(-)
+ set_up_default_resources.py | 43 +++++++++++++++++++++++++++----------
+ 1 file changed, 32 insertions(+), 11 deletions(-)
 
 diff --git a/set_up_default_resources.py b/set_up_default_resources.py
-index f5cd0ac..5bbb5e9 100755
+index f5cd0ac..8565d10 100755
 --- a/set_up_default_resources.py
 +++ b/set_up_default_resources.py
 @@ -96,21 +96,24 @@ class UseCase:
@@ -49,26 +53,38 @@ index f5cd0ac..5bbb5e9 100755
          use_cases = json.load(f)
          return [
              UseCase(
-@@ -579,7 +582,8 @@ def set_up_resources(
+@@ -579,7 +582,9 @@ def set_up_resources(
          additional_npu_config_names: tuple = (),
          arena_cache_size: int = 0,
          check_clean_folder: bool = False,
 -        additional_requirements_file: Path = ""
 +        additional_requirements_file: Path = "",
 +        use_case_resources_file: Path = "",
++        downloaded_model_resources_path: Path = "",
  ) -> Path:
      """
      Helpers function that retrieve the output from a command.
-@@ -597,6 +601,8 @@ def set_up_resources(
+@@ -597,6 +602,9 @@ def set_up_resources(
      additional_requirements_file (str): Path to a requirements.txt file if
                                          additional packages need to be
                                          installed.
 +    use_case_resources_file (str): Path to a JSON file containing the use case
 +                                   metadata resources.
++    downloaded_model_resources_path (str): Path to store model resources files.
  
      Returns
      -------
-@@ -619,7 +625,7 @@ def set_up_resources(
+@@ -608,8 +616,7 @@ def set_up_resources(
+     """
+     # Paths.
+     current_file_dir = Path(__file__).parent.resolve()
+-    download_dir = current_file_dir / "resources_downloaded"
+-    metadata_file_path = download_dir / "resources_downloaded_metadata.json"
++    metadata_file_path = downloaded_model_resources_path / "resources_downloaded_metadata.json"
+ 
+     # Is Python minimum requirement matched?
+     if sys.version_info < py3_version_minimum:
+@@ -619,18 +626,18 @@ def set_up_resources(
          )
      logging.info("Using Python version: %s", sys.version_info)
  
@@ -77,24 +93,62 @@ index f5cd0ac..5bbb5e9 100755
      setup_script_hash = get_md5sum_for_file(Path(__file__).resolve())
  
      metadata_dict, setup_script_hash_verified = initialize_resources_directory(
-@@ -706,6 +712,12 @@ if __name__ == "__main__":
+-        download_dir,
++        downloaded_model_resources_path,
+         check_clean_folder,
+         metadata_file_path,
+         setup_script_hash
+     )
+ 
+     env_path, env_activate = set_up_python_venv(
+-        download_dir,
++        downloaded_model_resources_path,
+         additional_requirements_file
+     )
+ 
+@@ -640,7 +647,7 @@ def set_up_resources(
+         download_resources(
+             use_case,
+             metadata_dict,
+-            download_dir,
++            downloaded_model_resources_path,
+             check_clean_folder,
+             setup_script_hash_verified
+         )
+@@ -657,7 +664,7 @@ def set_up_resources(
+         # Consolidate all config names while discarding duplicates:
+         run_vela_on_all_models(
+             current_file_dir,
+-            download_dir,
++            downloaded_model_resources_path,
+             env_activate,
+             arena_cache_size,
+             npu_config_names=list(set(default_npu_config_names + list(additional_npu_config_names)))
+@@ -706,6 +713,18 @@ if __name__ == "__main__":
          type=str,
          default=Path(__file__).parent.resolve() / 'scripts' / 'py' / 'requirements.txt'
      )
 +    parser.add_argument(
 +         "--use-case-resources-file",
 +        help="Path to the use case resources file",
-+        type=str,
++        type=Path,
 +        default=Path(__file__).parent.resolve() / 'scripts' / 'py' / 'use_case_resources.json'
++    )
++    parser.add_argument(
++         "--downloaded-model-resources-path",
++        help="Path to downloaded model resources",
++        type=Path,
++        default=Path(__file__).parent.resolve() / 'resources_downloaded'
 +    )
  
      args = parser.parse_args()
  
-@@ -724,4 +736,5 @@ if __name__ == "__main__":
+@@ -724,4 +743,6 @@ if __name__ == "__main__":
          args.arena_cache_size,
          args.clean,
          args.requirements_file,
 +        args.use_case_resources_file,
++        args.downloaded_model_resources_path,
      )
 -- 
 2.34.1

--- a/release_changes/202403121559.change
+++ b/release_changes/202403121559.change
@@ -1,0 +1,1 @@
+ml-apps: Fix building different ML apps subsequently


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->

When building ML apps, the MLEK downloads model resources for the model specified by a given application.
The FRI integration of the MLEK prevents these resources from being re-donwloaded if they already exist to speed up build time.

However, in the case of a different application being build, model resources have to be re-downloaded as different ML applications use different models.
To allow the re-download of model resources, the generated ML model resources subdirectory is now generated in the CMake build directory.

Building a different application requires triggering a clean build which will also delete the resources specific to a model used by another application.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
