### PR TITLE
lib-tests-app: Fix build issue

### DIFF
--- a/applications/freertos_iot_libraries_tests/CMakeLists.txt
+++ b/applications/freertos_iot_libraries_tests/CMakeLists.txt
@@ -22,7 +22,7 @@ set(MCUBOOT_IMAGE_VERSION_NS_UPDATE "0.0.1+20")
 
 # Trusted Firmware-M setup
 set(TFM_CMAKE_APP_ARGS
-    -DPROJECT_CONFIG_HEADER_FILE=${IOT_REFERENCE_ARM_CORSTONE3XX_SOURCE_DIR}/applications/aws_iot_example/configs/tfm_config/project_config.h
+    -DPROJECT_CONFIG_HEADER_FILE=${IOT_REFERENCE_ARM_CORSTONE3XX_SOURCE_DIR}/applications/freertos_iot_libraries_tests/configs/tfm_config/project_config.h
     -DMCUBOOT_DATA_SHARING=ON
     -DMCUBOOT_CONFIRM_IMAGE=ON
     -DMCUBOOT_UPGRADE_STRATEGY=SWAP_USING_SCRATCH

--- a/release_changes/202403151803.change
+++ b/release_changes/202403151803.change
@@ -1,0 +1,1 @@
+lib-tests-app: Fix build issue


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->

The `freertos-iot-libraries-tests` application
was mistakenly relying on another app's TF-M configuration file. The other app (`aws-iot-example`) was removed along with its configuration files.

The `freertos-iot-libraries-tests` application now uses its own TF-M configuration file.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
