### PR TITLE
freertos-kernel: Update to `V11.1.0` release

### DIFF
--- a/applications/blinky/configs/freertos_config/CMakeLists.txt
+++ b/applications/blinky/configs/freertos_config/CMakeLists.txt
@@ -16,5 +16,4 @@ target_link_libraries(freertos_config
     INTERFACE
         tfm-ns-interface
         app-config
-        fri-bsp
 )

--- a/applications/freertos_iot_libraries_tests/configs/freertos_config/CMakeLists.txt
+++ b/applications/freertos_iot_libraries_tests/configs/freertos_config/CMakeLists.txt
@@ -16,5 +16,4 @@ target_link_libraries(freertos_config
     INTERFACE
         tfm-ns-interface
         app-config
-        fri-bsp
 )

--- a/applications/keyword_detection/configs/freertos_config/CMakeLists.txt
+++ b/applications/keyword_detection/configs/freertos_config/CMakeLists.txt
@@ -16,5 +16,4 @@ target_link_libraries(freertos_config
     INTERFACE
         tfm-ns-interface
         app-config
-        fri-bsp
 )

--- a/applications/object_detection/configs/freertos_config/CMakeLists.txt
+++ b/applications/object_detection/configs/freertos_config/CMakeLists.txt
@@ -16,5 +16,4 @@ target_link_libraries(freertos_config
     INTERFACE
         tfm-ns-interface
         app-config
-        fri-bsp
 )

--- a/applications/speech_recognition/configs/freertos_config/CMakeLists.txt
+++ b/applications/speech_recognition/configs/freertos_config/CMakeLists.txt
@@ -16,5 +16,4 @@ target_link_libraries(freertos_config
     INTERFACE
         tfm-ns-interface
         app-config
-        fri-bsp
 )

--- a/bsp/isp_mali-c55/integration/CMakeLists.txt
+++ b/bsp/isp_mali-c55/integration/CMakeLists.txt
@@ -38,7 +38,7 @@ add_library(isp_platform_driver_system)
 target_link_libraries(isp_platform_driver_system
     PUBLIC
         isp_driver
-        freertos_kernel_include
+        freertos_kernel
 )
 target_include_directories(isp_platform_driver_system
     PUBLIC
@@ -87,5 +87,5 @@ target_sources(isp_control
 
 target_link_libraries(isp_control
     isp_driver
-    freertos_kernel_include
+    freertos_kernel
 )

--- a/components/connectivity/freertos_plus_tcp/integration/CMakeLists.txt
+++ b/components/connectivity/freertos_plus_tcp/integration/CMakeLists.txt
@@ -14,6 +14,12 @@ target_include_directories(freertos_plus_tcp SYSTEM
 )
 
 target_link_libraries(freertos_plus_tcp
+    PUBLIC
+        # TODO: The CS315 network interface layer inside the FreeRTOS TCP/IP stack
+        # https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/source/portable/NetworkInterface/MPS4_CS315/Device/Include/SSE315.h#L62
+        # is done in such a way that it depends on fri-bsp. This dependency
+        # should be removed.
+        fri-bsp
     PRIVATE
         coremqtt
         helpers-events

--- a/components/freertos_kernel/CMakeLists.txt
+++ b/components/freertos_kernel/CMakeLists.txt
@@ -18,4 +18,10 @@ endif()
 
 # FreeRTOS requires the freertos_config library to exist first
 add_library(freertos_config INTERFACE)
+target_include_directories(freertos_config
+    INTERFACE
+        $<$<STREQUAL:${ARM_CORSTONE_BSP_TARGET_PLATFORM},corstone300>:${IOT_REFERENCE_ARM_CORSTONE3XX_SOURCE_DIR}/bsp/corstone300/include>
+        $<$<STREQUAL:${ARM_CORSTONE_BSP_TARGET_PLATFORM},corstone310>:${IOT_REFERENCE_ARM_CORSTONE3XX_SOURCE_DIR}/bsp/corstone310/include>
+        $<$<STREQUAL:${ARM_CORSTONE_BSP_TARGET_PLATFORM},corstone315>:${IOT_REFERENCE_ARM_CORSTONE3XX_SOURCE_DIR}/bsp/corstone315/include>
+)
 add_subdirectory(library)

--- a/manifest.yml
+++ b/manifest.yml
@@ -5,7 +5,7 @@ description: |-
 dependencies:
   - name: "FreeRTOS-Kernel"
     license: "MIT"
-    version: "V10.6.1"
+    version: "V11.1.0"
     repository:
       type: "git"
       url: "https://github.com/FreeRTOS/FreeRTOS-Kernel.git"

--- a/release_changes/202404301532.change
+++ b/release_changes/202404301532.change
@@ -1,0 +1,1 @@
+freertos-kernel: Update to `V11.1.0` release


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
Even though CMake supports circular dependency, but currently it is supported only for static libraries. If CMake detects a circular dependency which involves an object library then CMake stops. For more info, check https://gitlab.kitware.com/cmake/cmake/-/issues/17905.

With FreeRTOS-Kernel 11.1.0 release, FreeRTOS-Kernel produces a single static library. As part of this effort, `freertos_kernel_port` library has been changed to an `OBJECT` library. With our current dependency chain in FRI, this leads to a circular dependency with an object library. Therefore, remove the dependency of `freertos_config` on `fri-bsp` to avoid this. Because of this, we've to add the necessary includes from bsp to `freertos-config`.

The CS315 network interface layer inside the FreeRTOS TCP/IP stack https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/source/portable/NetworkInterface/MPS4_CS315/Device/Include/SSE315.h#L62 is done in such a way that it depends on fri-bsp. Therefore, add `freertos_plus_tcp` dependency on `fri-bsp`.

In general, a library A  depending on another library B should avoid linking against granular libraries defined inside the library B. This can cause build failures in future. Therefore, the dependency of `isp_platform_driver_system` and `isp_control` on
`freertos_kernel_include` has been changed to `freertos_kernel`.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
Changes validated on internal CI, no regression observed.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
