### PR TITLE
Increase mqtt keep alive

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -66,6 +66,7 @@ jobs:
           ./tools/ci/generate_credentials.sh -f -p applications/${APP_UNDERSCORED}/configs/aws_configs
           git config --global user.email "ci@example.com"
           git config --global user.name "ci"
+          git config --global core.autocrlf input
       - name: Build ${{ matrix.application }} application
         shell: bash
         run: |

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -54,6 +54,7 @@ workflow:
     - ./tools/ci/generate_credentials.sh -f -p applications/${APP_UNDERSCORED}/configs/aws_configs
     - git config --global user.email "ci@example.com"
     - git config --global user.name "ci"
+    - git config --global core.autocrlf input
     - |
       ./tools/scripts/build.sh ${APP} \
         --target $TARGET \

--- a/applications/freertos_iot_libraries_tests/CMakeLists.txt
+++ b/applications/freertos_iot_libraries_tests/CMakeLists.txt
@@ -61,10 +61,6 @@ add_subdirectory(../helpers ${CMAKE_BINARY_DIR}/helpers)
 
 # Configure FreeRTOS Libraries Integration Tests component
 add_dependencies(freertos-libraries-integration-tests-config provisioning_data_bin)
-target_sources(freertos-libraries-integration-tests-config
-    INTERFACE
-        integration_tests_platform_function.c
-)
 target_include_directories(freertos-libraries-integration-tests-config
     INTERFACE
         ${CMAKE_CURRENT_LIST_DIR}
@@ -88,6 +84,7 @@ target_link_libraries(freertos-libraries-integration-tests-config
 
 add_executable(${CMAKE_PROJECT_NAME}
     main.c
+    integration_tests_platform_function.c
 )
 
 # Trusted Firmware-M must be built before the application, because

--- a/components/tools/freertos_libraries_integration_tests/CMakeLists.txt
+++ b/components/tools/freertos_libraries_integration_tests/CMakeLists.txt
@@ -14,6 +14,7 @@ set(PATCH_FILES_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/integration/patches")
 set(PATCH_FILES
     "${PATCH_FILES_DIRECTORY}/0001-Reduce-the-TRANSPORT_TEST_BUFFER_WRITABLE_LENGTH.patch"
     "${PATCH_FILES_DIRECTORY}/0002-closefile-validsignature-test-Fix-test-bugs.patch"
+    "${PATCH_FILES_DIRECTORY}/0003-Increase-keep-alive-interval.patch"
 )
 iot_reference_arm_corstone3xx_apply_patches("${freertos_libraries_integration_tests_SOURCE_DIR}" "${PATCH_FILES}")
 

--- a/components/tools/freertos_libraries_integration_tests/CMakeLists.txt
+++ b/components/tools/freertos_libraries_integration_tests/CMakeLists.txt
@@ -15,6 +15,7 @@ set(PATCH_FILES
     "${PATCH_FILES_DIRECTORY}/0001-Reduce-the-TRANSPORT_TEST_BUFFER_WRITABLE_LENGTH.patch"
     "${PATCH_FILES_DIRECTORY}/0002-closefile-validsignature-test-Fix-test-bugs.patch"
     "${PATCH_FILES_DIRECTORY}/0003-Increase-keep-alive-interval.patch"
+    "${PATCH_FILES_DIRECTORY}/0004-Enable-access-to-mbedtls-private-fields.patch"
 )
 iot_reference_arm_corstone3xx_apply_patches("${freertos_libraries_integration_tests_SOURCE_DIR}" "${PATCH_FILES}")
 

--- a/components/tools/freertos_libraries_integration_tests/integration/patches/0003-Increase-keep-alive-interval.patch
+++ b/components/tools/freertos_libraries_integration_tests/integration/patches/0003-Increase-keep-alive-interval.patch
@@ -1,0 +1,31 @@
+From 707d4500880cc3e657a6fa0c76aed2c710c0158e Mon Sep 17 00:00:00 2001
+From: Devaraj Ranganna <devaraj.ranganna@arm.com>
+Date: Tue, 21 May 2024 11:44:48 +0000
+Subject: [PATCH] Increase keep-alive interval
+
+The MQTT server resets connection if the device doesn't send keep alive
+packets within keep-alive interval, which is configured to 5 seconds by
+default. Increase the keep-alive interval to 60 seconds to avoid connection
+reset request when the device is busy.
+
+Signed-off-by: Devaraj Ranganna <devaraj.ranganna@arm.com>
+---
+ src/mqtt/mqtt_test.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/mqtt/mqtt_test.c b/src/mqtt/mqtt_test.c
+index eadc176..14d30c5 100644
+--- a/src/mqtt/mqtt_test.c
++++ b/src/mqtt/mqtt_test.c
+@@ -170,7 +170,7 @@
+  * @brief Time interval in seconds at which an MQTT PINGREQ need to be sent to
+  * broker.
+  */
+-#define MQTT_KEEP_ALIVE_INTERVAL_SECONDS    ( 5U )
++#define MQTT_KEEP_ALIVE_INTERVAL_SECONDS    ( 60U )
+
+ /**
+  * @brief The MQTT message published in this example.
+--
+2.43.2
+

--- a/components/tools/freertos_libraries_integration_tests/integration/patches/0004-Enable-access-to-mbedtls-private-fields.patch
+++ b/components/tools/freertos_libraries_integration_tests/integration/patches/0004-Enable-access-to-mbedtls-private-fields.patch
@@ -1,0 +1,32 @@
+From c5a51e721331175a3ea3f42093c4336ad2697889 Mon Sep 17 00:00:00 2001
+From: Devaraj Ranganna <devaraj.ranganna@arm.com>
+Date: Tue, 21 May 2024 12:56:39 +0000
+Subject: [PATCH] Enable access to mbedtls "private" fields
+
+Define the macro `MBEDTLS_ALLOW_PRIVATE_ACCESS` so that, the Mbed TLS structure
+fields that are marked as private are still accessible.
+
+Signed-off-by: Devaraj Ranganna <devaraj.ranganna@arm.com>
+---
+ src/pkcs11/core_pkcs11_test.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/src/pkcs11/core_pkcs11_test.c b/src/pkcs11/core_pkcs11_test.c
+index 71bad5a..6dcc8b5 100644
+--- a/src/pkcs11/core_pkcs11_test.c
++++ b/src/pkcs11/core_pkcs11_test.c
+@@ -32,6 +32,11 @@
+ #include <stdlib.h>
+ #include <string.h>
+
++/**
++ *  @brief Declaring MBEDTLS_ALLOW_PRIVATE_ACCESS allows access to mbedtls "private" fields.
++ */
++#define MBEDTLS_ALLOW_PRIVATE_ACCESS
++
+ /* corePKCS11 includes. */
+ #include "core_pki_utils.h"
+ #include "core_pkcs11.h"
+--
+2.43.2
+

--- a/release_changes/202405211228.change
+++ b/release_changes/202405211228.change
@@ -1,0 +1,1 @@
+integration-tests: Increase keep-alive interval


### PR DESCRIPTION
<!--- Title -->

Description
-----------
The MQTT server resets connection if the device doesn't send keep alive packets within keep-alive interval, which is configured to 5 seconds by default. Increase the keep-alive interval to 60 seconds to avoid connection reset request when the device is busy.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
Validated the changes in the nightly, no regressions observed.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
