### PR TITLE
internal-ci: Add support for testing IoT_vSocket connectivity stack in nightly tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -62,13 +62,14 @@ workflow:
         --audio $AUDIO \
         --toolchain $TOOLCHAIN \
         --certificate_path $PWD/certificate.pem \
-        --private_key_path $PWD/private_key.pem
+        --private_key_path $PWD/private_key.pem \
+        --conn-stack $CONN_STACK
     - |
       if [ $APP == "blinky" ];then
-        tar -czf ${TARGET}_${APP}_${TOOLCHAIN}_${INFERENCE}_${AUDIO}_build.tar.gz \
+        tar -czf ${TARGET}_${APP}_${TOOLCHAIN}_${INFERENCE}_${AUDIO}_${CONN_STACK}_build.tar.gz \
           build/${APP}_merged.elf
       else
-        tar -czf ${TARGET}_${APP}_${TOOLCHAIN}_${INFERENCE}_${AUDIO}_build.tar.gz \
+        tar -czf ${TARGET}_${APP}_${TOOLCHAIN}_${INFERENCE}_${AUDIO}_${CONN_STACK}_build.tar.gz \
           build/${APP}_merged.elf \
           build/${APP}-update_signed.bin \
           build/update-signature.txt \
@@ -86,9 +87,10 @@ build-applications-corstone315:
          APP: [blinky, keyword-detection, speech-recognition, object-detection]
          INFERENCE: [ETHOS]
          AUDIO: [ROM]
+         CONN_STACK: [FREERTOS_PLUS_TCP]
   artifacts:
     paths:
-      - ${TARGET}_${APP}_${TOOLCHAIN}_${INFERENCE}_${AUDIO}_build.tar.gz
+      - ${TARGET}_${APP}_${TOOLCHAIN}_${INFERENCE}_${AUDIO}_${CONN_STACK}_build.tar.gz
     expire_in: 1 week
   variables:
     GIT_SUBMODULE_STRATEGY: recursive
@@ -104,9 +106,10 @@ build-applications-corstone310:
          APP: [blinky, keyword-detection, speech-recognition]
          INFERENCE: [ETHOS]
          AUDIO: [ROM]
+         CONN_STACK: [FREERTOS_PLUS_TCP]
   artifacts:
     paths:
-      - ${TARGET}_${APP}_${TOOLCHAIN}_${INFERENCE}_${AUDIO}_build.tar.gz
+      - ${TARGET}_${APP}_${TOOLCHAIN}_${INFERENCE}_${AUDIO}_${CONN_STACK}_build.tar.gz
     expire_in: 1 week
   variables:
     GIT_SUBMODULE_STRATEGY: recursive
@@ -122,9 +125,10 @@ build-applications-corstone300:
          APP: [blinky, keyword-detection, speech-recognition]
          INFERENCE: [ETHOS]
          AUDIO: [ROM]
+         CONN_STACK: [FREERTOS_PLUS_TCP]
   artifacts:
     paths:
-      - ${TARGET}_${APP}_${TOOLCHAIN}_${INFERENCE}_${AUDIO}_build.tar.gz
+      - ${TARGET}_${APP}_${TOOLCHAIN}_${INFERENCE}_${AUDIO}_${CONN_STACK}_build.tar.gz
     expire_in: 1 week
   variables:
     GIT_SUBMODULE_STRATEGY: recursive
@@ -167,7 +171,7 @@ test-blinky-output:
     - job: build-applications-corstone300
       artifacts: true
   script:
-    - tar xf ${TARGET}_${APP}_${TOOLCHAIN}_${INFERENCE}_${AUDIO}_build.tar.gz
+    - tar xf ${TARGET}_${APP}_${TOOLCHAIN}_${INFERENCE}_${AUDIO}_${CONN_STACK}_build.tar.gz
     - |
         pytest -s tools/tests/test_blinky_output.py \
         --build-artefacts-path "build" \
@@ -183,23 +187,26 @@ test-blinky-output:
          APP: [blinky]
          INFERENCE: [ETHOS]
          AUDIO: [ROM]
+         CONN_STACK: [FREERTOS_PLUS_TCP]
        -
          << : [*pipeline_config_corstone310, *pipeline_config_toolchain]
          APP: [blinky]
          INFERENCE: [ETHOS]
          AUDIO: [ROM]
+         CONN_STACK: [FREERTOS_PLUS_TCP]
        -
          << : [*pipeline_config_corstone300, *pipeline_config_toolchain]
          APP: [blinky]
          INFERENCE: [ETHOS]
          AUDIO: [ROM]
+         CONN_STACK: [FREERTOS_PLUS_TCP]
 
 .test-applications_base:
   extends: .test_job
   script:
     - |
-      if [[ -f "${TARGET}_${APP}_${TOOLCHAIN}_${INFERENCE}_${AUDIO}_build.tar.gz" ]]; then
-        tar xf ${TARGET}_${APP}_${TOOLCHAIN}_${INFERENCE}_${AUDIO}_build.tar.gz
+      if [[ -f "${TARGET}_${APP}_${TOOLCHAIN}_${INFERENCE}_${AUDIO}_${CONN_STACK}_build.tar.gz" ]]; then
+        tar xf ${TARGET}_${APP}_${TOOLCHAIN}_${INFERENCE}_${AUDIO}_${CONN_STACK}_build.tar.gz
       fi
     - export APP_UNDERSCORED=$(echo ${APP} | tr '-' '_')
     - |
@@ -257,18 +264,21 @@ test-ml-applications-output:
          INFERENCE: [ETHOS]
          AUDIO: [ROM]
          TOOLCHAIN: [ARMCLANG]
+         CONN_STACK: [FREERTOS_PLUS_TCP]
        -
          << : *pipeline_config_corstone310
          APP: [keyword-detection, speech-recognition]
          INFERENCE: [ETHOS]
          AUDIO: [ROM]
          TOOLCHAIN: [ARMCLANG]
+         CONN_STACK: [FREERTOS_PLUS_TCP]
        -
          << : *pipeline_config_corstone300
          APP: [keyword-detection, speech-recognition]
          INFERENCE: [ETHOS]
          AUDIO: [ROM]
          TOOLCHAIN: [ARMCLANG]
+         CONN_STACK: [FREERTOS_PLUS_TCP]
 
 integration-tests:
   extends: .test_job
@@ -294,7 +304,7 @@ integration-tests:
     # communicate with the server.
     - host_ip_address=`ifconfig eth0 | grep -w 'inet' | awk '{print $2}'`
     - sed -i "s/#define ECHO_SERVER_ENDPOINT .*$/#define ECHO_SERVER_ENDPOINT \"$host_ip_address\"/g" applications/freertos_iot_libraries_tests/test_param_config.h
-    - ./tools/scripts/build.sh ${APP} --target $TARGET --toolchain $TOOLCHAIN --certificate_path $PWD/certificate.pem  --private_key_path $PWD/private_key.pem
+    - ./tools/scripts/build.sh ${APP} --target $TARGET --toolchain $TOOLCHAIN --certificate_path $PWD/certificate.pem  --private_key_path $PWD/private_key.pem --conn-stack $CONN_STACK
     - pushd components/tools/freertos_libraries_integration_tests/library/tools/echo_server
     - go run echo_server.go&
     - popd
@@ -312,12 +322,15 @@ integration-tests:
       -
         << : [*pipeline_config_corstone315, *pipeline_config_toolchain]
         APP: [freertos-iot-libraries-tests]
+        CONN_STACK: [FREERTOS_PLUS_TCP, IOT_VSOCKET]
       -
         << : [*pipeline_config_corstone310, *pipeline_config_toolchain]
         APP: [freertos-iot-libraries-tests]
+        CONN_STACK: [FREERTOS_PLUS_TCP, IOT_VSOCKET]
       -
         << : [*pipeline_config_corstone300, *pipeline_config_toolchain]
         APP: [freertos-iot-libraries-tests]
+        CONN_STACK: [FREERTOS_PLUS_TCP, IOT_VSOCKET]
   retry:
     max: 2
     when:
@@ -351,42 +364,49 @@ sw-vsi-configs-test:
          INFERENCE: [ETHOS]
          AUDIO: [VSI]
          TOOLCHAIN: [ARMCLANG]
+         CONN_STACK: [FREERTOS_PLUS_TCP]
        -
          << : *pipeline_config_corstone315
          APP: [keyword-detection, speech-recognition]
          INFERENCE: [SOFTWARE]
          AUDIO: [ROM, VSI]
          TOOLCHAIN: [ARMCLANG]
+         CONN_STACK: [FREERTOS_PLUS_TCP]
        -
          << : *pipeline_config_corstone315
          APP: [object-detection]
          INFERENCE: [SOFTWARE]
          AUDIO: [ROM]
          TOOLCHAIN: [ARMCLANG]
+         CONN_STACK: [FREERTOS_PLUS_TCP]
        -
          << : *pipeline_config_corstone310
          APP: [keyword-detection, speech-recognition]
          INFERENCE: [ETHOS]
          AUDIO: [VSI]
          TOOLCHAIN: [ARMCLANG]
+         CONN_STACK: [FREERTOS_PLUS_TCP]
        -
          << : *pipeline_config_corstone310
          APP: [keyword-detection, speech-recognition]
          INFERENCE: [SOFTWARE]
          AUDIO: [ROM, VSI]
          TOOLCHAIN: [ARMCLANG]
+         CONN_STACK: [FREERTOS_PLUS_TCP]
        -
          << : *pipeline_config_corstone300
          APP: [keyword-detection, speech-recognition]
          INFERENCE: [ETHOS]
          AUDIO: [VSI]
          TOOLCHAIN: [ARMCLANG]
+         CONN_STACK: [FREERTOS_PLUS_TCP]
        -
          << : *pipeline_config_corstone300
          APP: [keyword-detection, speech-recognition]
          INFERENCE: [SOFTWARE]
          AUDIO: [ROM, VSI]
          TOOLCHAIN: [ARMCLANG]
+         CONN_STACK: [FREERTOS_PLUS_TCP]
   retry:
     max: 2
     when:
@@ -420,24 +440,83 @@ gnu-toolchain-test:
          INFERENCE: [ETHOS, SOFTWARE]
          AUDIO: [ROM,VSI]
          TOOLCHAIN: [GNU]
+         CONN_STACK: [FREERTOS_PLUS_TCP]
        -
          << : *pipeline_config_corstone315
          APP: [object-detection]
          INFERENCE: [ETHOS, SOFTWARE]
          AUDIO: [ROM]
          TOOLCHAIN: [GNU]
+         CONN_STACK: [FREERTOS_PLUS_TCP]
        -
          << : *pipeline_config_corstone310
          APP: [keyword-detection, speech-recognition]
          INFERENCE: [ETHOS, SOFTWARE]
          AUDIO: [ROM,VSI]
          TOOLCHAIN: [GNU]
+         CONN_STACK: [FREERTOS_PLUS_TCP]
        -
          << : *pipeline_config_corstone300
          APP: [keyword-detection, speech-recognition]
          INFERENCE: [ETHOS, SOFTWARE]
          AUDIO: [ROM,VSI]
          TOOLCHAIN: [GNU]
+         CONN_STACK: [FREERTOS_PLUS_TCP]
+  retry:
+    max: 2
+    when:
+      - script_failure
+      - stuck_or_timeout_failure
+      - runner_system_failure
+  variables:
+    GIT_SUBMODULE_STRATEGY: recursive
+
+iot-vsocket-test:
+  tags:
+    - iotmsw-amd64
+  extends: .base-job-rules
+  rules:
+  - if: ( $SCHEDULED_JOB_TO_RUN == "iot-vsocket-test" )
+  before_script:
+    - !reference [.build_job, before_script]
+    - !reference [.build_job, script]
+  script:
+    # test_job's `before_script` section is referenced in the `script` section to set the correct value for FVP_BIN variable used in testing.
+    # test-applications_base job's `script` section is referenced in the `script` section of
+    # this job to do the testing part after the build stage is done where the build stage is inherited
+    # from `.build_job`
+    - !reference [.test_job, before_script]
+    - !reference [.test-applications_base, script]
+  parallel:
+    matrix:
+       -
+         << : *pipeline_config_corstone315
+         APP: [keyword-detection, speech-recognition]
+         INFERENCE: [ETHOS]
+         AUDIO: [ROM]
+         TOOLCHAIN: [GNU, ARMCLANG]
+         CONN_STACK: [IOT_VSOCKET]
+       -
+         << : *pipeline_config_corstone315
+         APP: [object-detection]
+         INFERENCE: [ETHOS]
+         AUDIO: [ROM]
+         TOOLCHAIN: [GNU, ARMCLANG]
+         CONN_STACK: [IOT_VSOCKET]
+       -
+         << : *pipeline_config_corstone310
+         APP: [keyword-detection, speech-recognition]
+         INFERENCE: [ETHOS]
+         AUDIO: [ROM]
+         TOOLCHAIN: [GNU, ARMCLANG]
+         CONN_STACK: [IOT_VSOCKET]
+       -
+         << : *pipeline_config_corstone300
+         APP: [keyword-detection, speech-recognition]
+         INFERENCE: [ETHOS]
+         AUDIO: [ROM]
+         TOOLCHAIN: [GNU, ARMCLANG]
+         CONN_STACK: [IOT_VSOCKET]
   retry:
     max: 2
     when:

--- a/applications/helpers/CMakeLists.txt
+++ b/applications/helpers/CMakeLists.txt
@@ -7,4 +7,9 @@ add_subdirectory(events)
 add_subdirectory(hdlcd)
 add_subdirectory(logging)
 add_subdirectory(provisioning)
-add_subdirectory(sntp)
+# sntp helper library depends on FreeRTOS-Plus-TCP connectivity stack as it
+# includes `FreeRTOS_IP.h` header file in one of its source files (sntp_client_task.c),
+# thus this library is only added in case of using FREERTOS_PLUS_TCP connectivity stack.
+if(CONNECTIVITY_STACK STREQUAL "FREERTOS_PLUS_TCP")
+    add_subdirectory(sntp)
+endif()

--- a/applications/keyword_detection/CMakeLists.txt
+++ b/applications/keyword_detection/CMakeLists.txt
@@ -136,13 +136,11 @@ target_link_libraries(keyword-detection
         coremqtt
         coremqtt-agent
         corepkcs11
-        coresntp
         freertos_kernel
         freertos-ota-pal-psa
         fri-bsp
         helpers-device-advisor
         helpers-events
-        helpers-sntp
         mbedtls
         ota-for-aws-iot-embedded-sdk
         provisioning-lib
@@ -151,6 +149,17 @@ target_link_libraries(keyword-detection
         kws_api
         kws_model
 )
+
+# sntp helper library depends on FreeRTOS-Plus-TCP connectivity stack as it
+# includes `FreeRTOS_IP.h` header file in one of its source files (sntp_client_task.c),
+# thus this library is only added in case of using FREERTOS_PLUS_TCP connectivity stack.
+if(CONNECTIVITY_STACK STREQUAL "FREERTOS_PLUS_TCP")
+    target_link_libraries(keyword-detection
+        PRIVATE
+            coresntp
+            helpers-sntp
+    )
+endif()
 
 include(${IOT_REFERENCE_ARM_CORSTONE3XX_SOURCE_DIR}/bsp/cmake/SetLinkerOptions.cmake)
 set_linker_script(keyword-detection)

--- a/components/aws_iot/CMakeLists.txt
+++ b/components/aws_iot/CMakeLists.txt
@@ -6,6 +6,11 @@ add_subdirectory(corejson)
 add_subdirectory(coremqtt)
 add_subdirectory(coremqtt_agent)
 add_subdirectory(corepkcs11)
-add_subdirectory(coresntp)
+# sntp helper library depends on FreeRTOS-Plus-TCP connectivity stack as it
+# includes `FreeRTOS_IP.h` header file in one of its source files (sntp_client_task.c),
+# thus the coresntp library is only added in case of using FREERTOS_PLUS_TCP connectivity stack.
+if(CONNECTIVITY_STACK STREQUAL "FREERTOS_PLUS_TCP")
+    add_subdirectory(coresntp)
+endif()
 add_subdirectory(ota_for_aws_iot_embedded_sdk)
 add_subdirectory(tinycbor)

--- a/docs/project_organisation.md
+++ b/docs/project_organisation.md
@@ -244,13 +244,11 @@ target_link_libraries(keyword-detection
         coremqtt
         coremqtt-agent
         corepkcs11
-        coresntp
         freertos_kernel
         freertos-ota-pal-psa
         fri-bsp
         helpers-device-advisor
         helpers-events
-        helpers-sntp
         kws_api
         kws_model
         mbedtls
@@ -260,6 +258,17 @@ target_link_libraries(keyword-detection
         tfm-ns-interface
         toolchain-override
 )
+
+# sntp helper library depends on FreeRTOS-Plus-TCP connectivity stack as it
+# includes `FreeRTOS_IP.h` header file in one of its source files (sntp_client_task.c),
+# thus this library is only added in case of using FREERTOS_PLUS_TCP connectivity stack.
+if(CONNECTIVITY_STACK STREQUAL "FREERTOS_PLUS_TCP")
+    target_link_libraries(keyword-detection
+        PRIVATE
+            coresntp
+            helpers-sntp
+    )
+endif()
 ```
 *Figure 7: keyword-detection application linked library alphabetically ordered*
 

--- a/release_changes/202406241724.change
+++ b/release_changes/202406241724.change
@@ -1,0 +1,1 @@
+ci: Add IoT-vSocket stack nightly tests.

--- a/tools/scripts/build.sh
+++ b/tools/scripts/build.sh
@@ -23,6 +23,7 @@ TOOLCHAIN_FILE=""
 BUILD=1
 CERTIFICATE_PATH=""
 PRIVATE_KEY_PATH=""
+CONNECTIVITY_STACK="FREERTOS_PLUS_TCP"
 
 set -e
 
@@ -55,6 +56,7 @@ function build_with_cmake {
         cmake_args+=(-DIOT_REFERENCE_ARM_CORSTONE3XX_SOURCE_DIR=$ROOT)
         cmake_args+=(-DML_INFERENCE_ENGINE=$ML_INFERENCE_ENGINE)
         cmake_args+=(-DAUDIO_SOURCE=$AUDIO_SOURCE)
+        cmake_args+=(-DCONNECTIVITY_STACK=$CONNECTIVITY_STACK)
         if [ ! -z "$ETHOS_U_NPU_ID" ]; then
           cmake_args+=(-DETHOS_U_NPU_ID=$ETHOS_U_NPU_ID)
         else
@@ -91,6 +93,7 @@ Options:
     -T,--toolchain                 Compiler (GNU or ARMCLANG)
     -C,--certificate_path          Path to the AWS device certificate
     -P,--private_key_path          Path to the AWS device private key
+    --conn-stack                   Connectivity stack selection (FREERTOS_PLUS_TCP | IOT_VSOCKET)
 Examples:
     blinky, freertos-iot-libraries-tests, keyword-detection, object-detection, speech-recognition
 EOF
@@ -102,7 +105,7 @@ if [[ $# -eq 0 ]]; then
 fi
 
 SHORT=t:,i:,T:,s:,c,h,C:,P:p:,n:
-LONG=target:,inference:,toolchain:,audio:,clean,help,configure-only,certificate_path:,private_key_path:,path:,npu-id:,npu-mac:
+LONG=target:,inference:,toolchain:,audio:,clean,help,configure-only,certificate_path:,private_key_path:,path:,npu-id:,npu-mac:,conn-stack:
 OPTS=$(getopt -n build --options $SHORT --longoptions $LONG -- "$@")
 
 eval set -- "$OPTS"
@@ -152,6 +155,10 @@ do
       ;;
     -P | --private_key_path )
       PRIVATE_KEY_PATH=$(realpath "$2")
+      shift 2
+      ;;
+    --conn-stack )
+      CONNECTIVITY_STACK=$2
       shift 2
       ;;
     --)
@@ -262,6 +269,18 @@ case "$TOOLCHAIN" in
       show_usage
       exit 2
       ;;
+esac
+
+case "$CONNECTIVITY_STACK" in
+    FREERTOS_PLUS_TCP )
+        ;;
+    IOT_VSOCKET )
+        ;;
+    *)
+        echo "Invalid connectivity stack selection <FREERTOS_PLUS_TCP | IOT_VSOCKET>"
+        show_usage
+        exit 2
+        ;;
 esac
 
 if [ "$EXAMPLE" != "blinky" ] && [ ! -f "$CERTIFICATE_PATH" ]; then


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
Internal CI nightly tests should support testing FRI applications/integration tests using `FreeRTOS-Plus-TCP` and `IoT_vSocket` connectivity stacks, to do so, the following changes were made: 
* Integration tests nightly job is modified to use both stacks
* A new job is added to test FRI applications with `IoT_vSocket` stack as FreeRTOS-Plus-TCP stack is already covered by all other jobs.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
