### PR TITLE
freerots-pkcs11-psa: Update to latest version

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -54,7 +54,7 @@ dependencies:
   - name: "freertos-pkcs11-psa"
     license: "MIT"
     tpip-category: "category-2"
-    version: "53fa27b097dd09d07781ab1a22e79273557f22b1"
+    version: "6caaf973920df9ae6823ef9be42f7e86aa91d168"
     repository:
       type: "git"
       url: "https://github.com/Linaro/freertos-pkcs11-psa.git"

--- a/release_changes/202407250924.change
+++ b/release_changes/202407250924.change
@@ -1,0 +1,1 @@
+freerots-pkcs11-psa: Update to latest version


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
The latest version contains a fix for memory leak in `C_FindObjects` API and using key IDs instead of deprecated key handles (Mbed TLS 3.6.0).

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
Validated the changes in the CI, no regressions observed.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
