### PR TITLE
 Implement single command for all steps of creating OTA update

### DIFF
--- a/.github/.cSpellWords.txt
+++ b/.github/.cSpellWords.txt
@@ -151,6 +151,8 @@ MQTT
 MQTT's
 mqttexample
 MVEI
+mytestthing
+myTestThing
 Mzrdfkvi
 nents
 NIOS
@@ -196,6 +198,7 @@ SECP
 sntp
 Sntp
 SNTP
+someTestThing
 speex
 Speex
 SPEEX
@@ -208,6 +211,7 @@ SSSZ
 suppr
 SYSWDOG
 TALGORITHMS
+testThing
 TGENERAL
 THEIGHT
 tinycbor

--- a/release_changes/202408300915.change
+++ b/release_changes/202408300915.change
@@ -1,0 +1,1 @@
+tools: Add command to createIoTThings.py for creating OTA updates.

--- a/tools/scripts/createIoTThings.py
+++ b/tools/scripts/createIoTThings.py
@@ -510,16 +510,11 @@ def _write_aws_clientcredential_h(flags):
     Parameters:
     flags (Flags): contains metadata needed for AWS and OTA updates
         (e.g. credentials).
-    fileDir (str): the project's base directory. E.g. contains top-level README.md.
     """
     fileDir = os.path.dirname(os.path.realpath("__file__"))
     template_has_correct_format = (
         lambda contents: "clientcredentialMQTT_BROKER_ENDPOINT " in contents
         and "clientcredentialIOT_THING_NAME " in contents
-    )
-    template_has_been_edited = (
-        lambda contents: "dummy.endpointid.amazonaws.com" not in contents
-        or "dummy_thingname" not in contents
     )
     # Try to find a template for 'aws_clientcredential.h'
     template = ""
@@ -550,7 +545,22 @@ def _write_aws_clientcredential_h(flags):
         )
         logging.warning(err_msg)
         return False
-    if template_has_been_edited(template):
+    # if template has been edited, ask before overwriting.
+    DEFAULT_ENDPOINT = (
+        "#define clientcredentialMQTT_BROKER_ENDPOINT    "
+        + 'dummy.endpointid.amazonaws.com"'
+    )
+    DEFAULT_THING_NAME = (
+        "#define clientcredentialIOT_THING_NAME               " '"dummy_thingname"'
+    )
+    # Remove spaces for robustness.
+    template_without_spaces = template.replace(" ", "")
+    if (
+        DEFAULT_ENDPOINT.replace(" ", "") in template_without_spaces
+        and DEFAULT_THING_NAME.replace(" ", "") in template_without_spaces
+    ):
+        logging.debug("aws_clientcredential.h has not been edited. Overwriting.")
+    else:
         warn_msg = (
             "Your aws_clientcredential.h file at "
             + credentialFileTemplate

--- a/tools/scripts/createIoTThings_settings.json
+++ b/tools/scripts/createIoTThings_settings.json
@@ -1,0 +1,47 @@
+{
+    "thing_name":"<your_thing_name>",
+    "permissions_boundary":"arn:aws:iam::<account_no>:policy/<boundary_name>",
+    "role_prefix":"<prefix>",
+    "target_application":"",
+
+    "format_vars":"thing_name;role_prefix;target_application;credentials_path",
+
+    "policy_name":"",
+    "bucket_name":"${thing_name}{lower}-bucket",
+    "iam_role_name":"",
+    "update_name":"",
+    "existing_certificate_arn":"CREATE_NEW_CERTIFICATE",
+
+
+    "credentials_path":"certificates",
+    "build_dir":"build",
+    "ota_binary":"${target_application}-update_signed.bin",
+
+    "skip_build":"",
+    "build_script_path":"",
+    "private_key_path":"",
+    "certificate_path":"",
+    "target_platform":"",
+    "inference":"",
+    "audio":"",
+    "toolchain":"",
+    "clean_build":"",
+
+    "policy_name_DEFAULT":"${thing_name}_policy",
+    "bucket_name_DEFAULT":"${thing_name}_bucket",
+    "iam_role_name_DEFAULT":"${role_prefix}-${thing_name}_role",
+    "update_name_DEFAULT":"${thing_name}_update",
+    "existing_certificate_arn_DEFAULT":"",
+    "credentials_path_DEFAULT":"",
+    "build_dir_DEFAULT":"",
+    "ota_binary_DEFAULT":"",
+    "skip_build_DEFAULT":"false",
+    "build_script_path_DEFAULT":"./tools/scripts/build.sh",
+    "private_key_path_DEFAULT":"${credentials_path}/thing_private_key_${thing_name}.pem.key",
+    "certificate_path_DEFAULT":"${credentials_path}/thing_certificate_${thing_name}.pem.crt",
+    "target_platform_DEFAULT":"corstone315",
+    "inference_DEFAULT":"SOFTWARE",
+    "audio_DEFAULT":"ROM",
+    "toolchain_DEFAULT":"GNU",
+    "clean_build":"auto"
+}


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Introduces a new command to `tools/scripts/createIoTThings.py` that
1. Creates a Thing and Policy.
2. Re-builds the target application (if required).
3. Creates a Bucket, Role, and Update.

This command is documented in `aws_tool.md`.

The command takes at most 2 command line arguments, with the rest
specified in a .json file, an example of which is also included in This
commit as well as the `aws_tool.md` documentation.
Only 3 fields in the settings `.json` need to be filled in.

The command also re-uses AWS entities where possible. E.g. if
the role specified by the `.json` already exists, it checks it can access the Bucket
name specified before re-using the role.

The motivation for this commit is to make creating OTA updates
easier.

This MR also introduces a new command for cleaning up all
AWS entities specified by the .json config file.
This command is called `cleanup-simplified`.
It will force-delete everything (including bucket contents). This
is not configurable.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
