### PR TITLE
Update Mbed TLS to v3.6.1 release and Fix CI issue

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -34,7 +34,7 @@ dependencies:
     license: "Apache-2.0"
     tpip-category: "category-2"
     security-risk: "high"
-    version: "v3.6.0"
+    version: "v3.6.1"
     repository:
       type: "git"
       url: "https://github.com/Mbed-TLS/mbedtls.git"

--- a/release_changes/202410071620.change.md
+++ b/release_changes/202410071620.change.md
@@ -1,0 +1,1 @@
+components: Update Mbed TLS to v3.6.1 release

--- a/tools/ci/aws_cleanup.py
+++ b/tools/ci/aws_cleanup.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Arm Limited and/or its affiliates
+# Copyright 2023-2024 Arm Limited and/or its affiliates
 # <open-source-office@arm.com>
 # SPDX-License-Identifier: MIT
 
@@ -137,7 +137,7 @@ def process_things(nextToken: str) -> str:
 
 
 def process_buckets(nextToken: str) -> str:
-    response = s3.list_buckets(nextToken=nextToken)
+    response = s3.list_buckets(ContinuationToken=nextToken)
 
     for bucket in response["Buckets"]:
         bucket_name: str = bucket["Name"]


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
* Update Mbed TLS to v3.6.1 release
* Fix a CI issue
    * With latest version of `boto`, `s3.list_buckets` API expects `ContinuationToken` instead of `nextToken`.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
