### PR TITLE
Add OTA Orchestrator fixes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arm Limited and/or its affiliates
+# Copyright (c) 2023-2025 Arm Limited and/or its affiliates
 # <open-source-office@arm.com>
 # SPDX-License-Identifier: MIT
 
@@ -85,9 +85,9 @@ jobs:
           build/${{ matrix.application }}-update_signed.bin \
           build/update-signature.txt
       - name: Upload Build Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: FRI-build-logs
+          name: FRI-build-logs-${{ strategy.job-index }}
           path: |
             ${{ github.workspace }}/${{ matrix.application }}_gnu_build.tar.gz
           retention-days: 5

--- a/applications/helpers/ota_orchestrator/src/ota_orchestrator.c
+++ b/applications/helpers/ota_orchestrator/src/ota_orchestrator.c
@@ -1075,6 +1075,7 @@ STATIC void processOTAEvents()
                 case OtaPalNewImageBootFailed:
                 case OtaPalJobDocProcessingStateInvalid:
                     LogInfo( ( "No OTA job available. \n" ) );
+                    vOtaNotActiveHook();
                     break;
             }
 
@@ -1171,11 +1172,11 @@ STATIC void processOTAEvents()
             if( activateImage() == true )
             {
                 LogInfo( ( "Activated image.\n" ) );
-                nextEvent.eventId = OtaAgentEventActivateImage;
+
+                nextEvent.eventId = OtaAgentEventRequestJobDocument;
                 OtaSendEvent_FreeRTOS( &nextEvent );
             }
 
-            otaAgentState = OtaAgentStateStopped;
             break;
 
 

--- a/applications/helpers/ota_orchestrator/src/ota_os_freertos.c
+++ b/applications/helpers/ota_orchestrator/src/ota_os_freertos.c
@@ -1,6 +1,6 @@
 /*
  * Copyright Amazon.com, Inc. and its affiliates. All Rights Reserved.
- * Copyright 2024 Arm Limited and/or its affiliates
+ * Copyright 2024-2025 Arm Limited and/or its affiliates
  * <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: MIT
@@ -67,14 +67,14 @@ OtaOsStatus_t OtaInitEvent_FreeRTOS()
     {
         otaOsStatus = OtaOsEventQueueCreateFailed;
 
-        LogInfo( ( "Failed to create OTA Event queue: "
-                   "xQueueCreateStatic returned error: "
-                   "OtaOsStatus_t=%d \n",
-                   ( int ) otaOsStatus ) );
+        LogError( ( "Failed to create OTA Event queue: "
+                    "xQueueCreateStatic returned error: "
+                    "OtaOsStatus_t=%d \n",
+                    ( int ) otaOsStatus ) );
     }
     else
     {
-        LogInfo( ( "OTA Event Queue created.\n" ) );
+        LogDebug( ( "OTA Event Queue created.\n" ) );
     }
 
     return otaOsStatus;
@@ -90,16 +90,16 @@ OtaOsStatus_t OtaSendEvent_FreeRTOS( const void * pEventMsg )
 
     if( retVal == pdTRUE )
     {
-        LogInfo( ( "OTA Event sent.\n" ) );
+        LogDebug( ( "OTA Event sent.\n" ) );
     }
     else
     {
         otaOsStatus = OtaOsEventQueueSendFailed;
 
-        LogInfo( ( "Failed to send event to OTA Event Queue: "
-                   "xQueueSendToBack returned error: "
-                   "OtaOsStatus_t=%d \n",
-                   ( int ) otaOsStatus ) );
+        LogError( ( "Failed to send event to OTA Event Queue: "
+                    "xQueueSendToBack returned error: "
+                    "OtaOsStatus_t=%d \n",
+                    ( int ) otaOsStatus ) );
     }
 
     return otaOsStatus;
@@ -114,16 +114,16 @@ OtaOsStatus_t OtaReceiveEvent_FreeRTOS( void * pEventMsg )
 
     if( retVal == pdTRUE )
     {
-        LogInfo( ( "OTA Event received \n" ) );
+        LogDebug( ( "OTA Event received \n" ) );
     }
     else
     {
         otaOsStatus = OtaOsEventQueueReceiveFailed;
 
-        LogInfo( ( "Failed to receive event or timeout from OTA Event Queue: "
-                   "xQueueReceive returned error: "
-                   "OtaOsStatus_t=%d \n",
-                   ( int ) otaOsStatus ) );
+        LogDebug( ( "Failed to receive event or timeout from OTA Event Queue: "
+                    "xQueueReceive returned error: "
+                    "OtaOsStatus_t=%d \n",
+                    ( int ) otaOsStatus ) );
     }
 
     return otaOsStatus;
@@ -133,5 +133,5 @@ void OtaDeinitEvent_FreeRTOS()
 {
     vQueueDelete( otaEventQueue );
 
-    LogInfo( ( "OTA Event Queue Deleted. \n" ) );
+    LogDebug( ( "OTA Event Queue Deleted. \n" ) );
 }

--- a/components/aws_iot/coremqtt_agent/integration/src/mqtt_agent_task.c
+++ b/components/aws_iot/coremqtt_agent/integration/src/mqtt_agent_task.c
@@ -1,7 +1,7 @@
 /*
  * FreeRTOS V202012.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
- * Copyright 2023-2024 Arm Limited and/or its affiliates
+ * Copyright 2023-2025 Arm Limited and/or its affiliates
  * <open-source-office@arm.com>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -141,7 +141,7 @@
  *  absence of sending any other Control Packets, the Client MUST send a
  *  PINGREQ Packet.
  */
-#define MQTT_AGENT_KEEP_ALIVE_INTERVAL_SECONDS       ( 60U )
+#define MQTT_AGENT_KEEP_ALIVE_INTERVAL_SECONDS       ( 100U )
 
 /**
  * @brief Socket send and receive timeouts to use.  Specified in milliseconds.

--- a/release_changes/202501301446.change.md
+++ b/release_changes/202501301446.change.md
@@ -1,0 +1,2 @@
+ota-orchestrator: Add multiple enhancements and fixes.
+mqtt-agent: Increase MQTT Agent keep alive interval.


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->

Changes done as part of this PR:


- Do not suspend OTA agent after successful update.


- `vOtaNotActiveHook()` should be called whenever there are no OTA jobs available.


- Use `LogDebug` and `LogError` instead of `LogInfo` to follow the previous `ota-for-embedded-iot-sdk` library implementation (avoiding new issues).


- The `MQTT_AGENT_KEEP_ALIVE_INTERVAL_SECONDS` is increased to `100` as in case of using `SOFTWARE` inference with `speech-recognition` application the connection is dropped before the ML Inference is done as the software inference is generally much slower compared to the Ethos NPU. This connection drop cause the ML inference to have wrong results as the task is interrupted. Hence, increasing the keep alive interval to avoid the connection drop.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
