### PR TITLE
Fix conflicts with DISPLAY system wide variable

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -51,7 +51,7 @@
 	url = https://github.com/ThrowTheSwitch/Unity.git
 [submodule "ml_embedded_evaluation_kit"]
 	path = components/ai/ml_embedded_evaluation_kit/library
-	url = https://review.mlplatform.org/ml/ethos-u/ml-embedded-evaluation-kit.git
+	url = https://git.gitlab.arm.com/artificial-intelligence/ethos-u/ml-embedded-evaluation-kit.git
 [submodule "speexdsp"]
 	path = components/ai/speexdsp/library
 	url = https://gitlab.xiph.org/xiph/speexdsp.git

--- a/components/ai/ml_embedded_evaluation_kit/integration/README.md
+++ b/components/ai/ml_embedded_evaluation_kit/integration/README.md
@@ -35,6 +35,6 @@ This is provided to the build system by setting the path to the JSON file with t
 
 For more information about the ML Embedded Evaluation Kit, see the [ML Embedded Evaluation Kit documentation].
 
-[Build options]: https://review.mlplatform.org/plugins/gitiles/ml/ethos-u/ml-embedded-evaluation-kit/+/HEAD/docs/sections/building.md#build-options
+[Build options]: https://gitlab.arm.com/artificial-intelligence/ethos-u/ml-embedded-evaluation-kit/-/blob/main/docs/sections/building.md#build-options
 [SetupMlEmbeddedEvaluationKitLibraries.cmake]: ../../../../components/ai/ml_embedded_evaluation_kit/integration/cmake/SetupMlEmbeddedEvaluationKitLibraries.cmake
-[ML Embedded Evaluation Kit documentation]: https://review.mlplatform.org/plugins/gitiles/ml/ethos-u/ml-embedded-evaluation-kit/+/HEAD/docs/documentation.md
+[ML Embedded Evaluation Kit documentation]: https://gitlab.arm.com/artificial-intelligence/ethos-u/ml-embedded-evaluation-kit/-/blob/main/docs/documentation.md

--- a/components/ai/ml_embedded_evaluation_kit/integration/cmake/model/GenerateASRModel.cmake
+++ b/components/ai/ml_embedded_evaluation_kit/integration/cmake/model/GenerateASRModel.cmake
@@ -1,5 +1,5 @@
 #----------------------------------------------------------------------------
-#  SPDX-FileCopyrightText: Copyright 2021-2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+#  SPDX-FileCopyrightText: Copyright 2021-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
 #  SPDX-License-Identifier: Apache-2.0
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +14,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #----------------------------------------------------------------------------
-# This file is based on https://review.mlplatform.org/plugins/gitiles/ml/ethos-u/ml-embedded-evaluation-kit/+/refs/tags/23.08/source/use_case/asr/usecase.cmake
+# This file is based on https://gitlab.arm.com/artificial-intelligence/ethos-u/ml-embedded-evaluation-kit/-/blob/23.08/source/use_case/asr/usecase.cmake
 
 set(ASR_LABELS_TXT_FILE
     ${ml_embedded_evaluation_kit_SOURCE_DIR}/resources/asr/labels/labels_wav2letter.txt)

--- a/components/ai/ml_embedded_evaluation_kit/integration/cmake/model/GenerateKWSModel.cmake
+++ b/components/ai/ml_embedded_evaluation_kit/integration/cmake/model/GenerateKWSModel.cmake
@@ -1,5 +1,5 @@
 #----------------------------------------------------------------------------
-#  SPDX-FileCopyrightText: Copyright 2021-2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+#  SPDX-FileCopyrightText: Copyright 2021-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
 #  SPDX-License-Identifier: Apache-2.0
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +14,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #----------------------------------------------------------------------------
-# This file is based on https://review.mlplatform.org/plugins/gitiles/ml/ethos-u/ml-embedded-evaluation-kit/+/refs/tags/23.08/source/use_case/kws/usecase.cmake
+# This file is based on https://gitlab.arm.com/artificial-intelligence/ethos-u/ml-embedded-evaluation-kit/-/blob/23.08/source/use_case/kws/usecase.cmake
 
 set(KWS_LABELS_TXT_FILE
     ${ml_embedded_evaluation_kit_SOURCE_DIR}/resources/kws/labels/micronet_kws_labels.txt)

--- a/components/ai/ml_embedded_evaluation_kit/integration/cmake/model/GenerateObjectDetectionModel.cmake
+++ b/components/ai/ml_embedded_evaluation_kit/integration/cmake/model/GenerateObjectDetectionModel.cmake
@@ -1,5 +1,5 @@
 #----------------------------------------------------------------------------
-#  SPDX-FileCopyrightText: Copyright 2021-2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+#  SPDX-FileCopyrightText: Copyright 2021-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
 #  SPDX-License-Identifier: Apache-2.0
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +14,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #----------------------------------------------------------------------------
-# This file is based on https://review.mlplatform.org/plugins/gitiles/ml/ethos-u/ml-embedded-evaluation-kit/+/refs/tags/23.11/source/use_case/object_detection/usecase.cmake
+# This file is based on https://gitlab.arm.com/artificial-intelligence/ethos-u/ml-embedded-evaluation-kit/-/blob/23.08/source/use_case/object_detection/usecase.cmake
 
 set(OBJECT_DETECTION_IMAGE_SIZE 192)
 set(OBJECT_DETECTION_ANCHOR_1 "{38, 77, 47, 97, 61, 126}")

--- a/manifest.yml
+++ b/manifest.yml
@@ -172,7 +172,7 @@ dependencies:
     version: "ddb3ffdbcfc6f66dc3906e84158f235824536b4a"
     repository:
       type: "git"
-      url: "https://review.mlplatform.org/ml/ethos-u/ml-embedded-evaluation-kit.git"
+      url: "https://git.gitlab.arm.com/artificial-intelligence/ethos-u/ml-embedded-evaluation-kit.git"
       path: "components/ai/ml_embedded_evaluation_kit/library"
   - name: "speexdsp"
     license: "BSD-3-Clause"

--- a/release_changes/202503181254.change.md
+++ b/release_changes/202503181254.change.md
@@ -1,0 +1,3 @@
+run-script: Fix conflicts with DISPLAY system wide variable.
+mlek: Switch to public GitLab repo
+setuptools: Update to latest version

--- a/tools/ci/pipeline-baseline-fri.yml
+++ b/tools/ci/pipeline-baseline-fri.yml
@@ -1,4 +1,4 @@
-# Copyright 2021-2024 Arm Limited and/or its affiliates
+# Copyright 2021-2025 Arm Limited and/or its affiliates
 # <open-source-office@arm.com>
 # SPDX-License-Identifier: MIT
 
@@ -44,6 +44,10 @@ pre-commit:
     - .base-job-rules
   stage: quality-check
   script:
+    - python3 -m venv venv
+    - source venv/bin/activate
+    - pip install --upgrade pip setuptools
+    - pip install PyYAML click typing
     - pip install tools/ci -t $PWD
     - apt-get update -y
     - apt-get install fd-find -y

--- a/tools/scripts/run.sh
+++ b/tools/scripts/run.sh
@@ -14,8 +14,8 @@ NPU_ID=""
 FVP_BIN="FVP_Corstone_SSE-320"
 FRAMES=""
 OPTIONS=""
-DISPLAY=true
-DISPLAY_OPTIONS=""
+HDLCD_GUI=false
+HDLCD_GUI_OPTIONS=""
 
 set -e
 
@@ -33,15 +33,15 @@ Options:
     -n,--npu-id     NPU ID to use (U55, U65)
     -f,--frames     Path to camera frames for the ISP to stream
     -d,--debug      Path to debugger plugin to start FVP
-    -D,--display    Is display (GUI) available
+    -G,--gui        Is HDLCD GUI enabled
 
 Examples:
     blinky, keyword-detection, speech-recognition, object-detection
 EOF
 }
 
-SHORT=t:,n:,s:,h,p:,f:,d:,D:
-LONG=target:,npu-id:,audio:,help,path:,frames:,debug:,display:
+SHORT=t:,n:,s:,h,p:,f:,d:,G:
+LONG=target:,npu-id:,audio:,help,path:,frames:,debug:,gui:
 OPTS=$(getopt -n run --options $SHORT --longoptions $LONG -- "$@")
 
 eval set -- "$OPTS"
@@ -81,8 +81,8 @@ do
       fi
       shift 2
       ;;
-    -D | --display )
-      DISPLAY=$2
+    -G | --gui )
+      HDLCD_GUI=$2
       shift 2
       ;;
     --)
@@ -185,8 +185,8 @@ if [ -f "$GDB_PLUGIN" ]; then
   OPTIONS="--allow-debug-plugin --plugin $GDB_PLUGIN"
 fi
 
-if [ "$DISPLAY" = false ]; then
-  DISPLAY_OPTIONS="-C vis_hdlcd.disable_visualisation=1"
+if [ "$HDLCD_GUI" = false ]; then
+  HDLCD_GUI_OPTIONS="-C vis_hdlcd.disable_visualisation=1"
 fi
 
 case "$TARGET" in
@@ -203,7 +203,7 @@ case "$TARGET" in
       -C mps3_board.DISABLE_GATING=1"
       ;;
     corstone315 | corstone320 )
-      OPTIONS="$OPTIONS $DISPLAY_OPTIONS \
+      OPTIONS="$OPTIONS $HDLCD_GUI_OPTIONS \
       -C mps4_board.visualisation.disable-visualisation=1 \
       -C core_clk.mul=200000000 \
       -C mps4_board.smsc_91c111.enabled=1 \


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->

`DISPLAY` is a well-known system-wide variable used in Linux for GUI applications. Overwriting it in the script could lead to unintended side effects, especially when launching graphical applications. Renaming it to `HDLCD_GUI` to avoid such conflicts.

The current version of `setuptools` (59.6.0) is too old to meet the requirements of the packages installed during the pre-commit stage. To avoid conflicts with system packages, a virtual environment is used to update `setuptools` and then run pre-commit stage in internal CI.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
