### PR TITLE
Fix ARMclang Map file flag

### DIFF
--- a/bsp/cmake/SetLinkerOptions.cmake
+++ b/bsp/cmake/SetLinkerOptions.cmake
@@ -32,7 +32,9 @@ macro(set_linker_script executable_target)
                 $<$<STREQUAL:${ARM_CORSTONE_BSP_TARGET_PLATFORM},corstone315>:--scatter=${IOT_REFERENCE_ARM_CORSTONE3XX_SOURCE_DIR}/bsp/corstone315/corstone_315_ns.sct>
                 $<$<STREQUAL:${ARM_CORSTONE_BSP_TARGET_PLATFORM},corstone320>:--scatter=${IOT_REFERENCE_ARM_CORSTONE3XX_SOURCE_DIR}/bsp/corstone320/corstone_320_ns.sct>
                 --map
-                --list=${executable_target}.map
+                # --list option is set implicitly to '${executable_target}.map' in
+                # CMake versions < 4.x.x, hence it's only added explicitly in case of CMake versions > 4.0.0
+                $<$<VERSION_GREATER_EQUAL:${CMAKE_VERSION},4.0.0>:--list=${executable_target}.map>
                 --strict
         )
     endif()

--- a/release_changes/202505221237.change.md
+++ b/release_changes/202505221237.change.md
@@ -1,1 +1,2 @@
 armclang-map-file: Only add list option if CMake version greater than 4
+license: Exclude new gitlab tmp folder from license check

--- a/release_changes/202505221237.change.md
+++ b/release_changes/202505221237.change.md
@@ -1,0 +1,1 @@
+armclang-map-file: Only add list option if CMake version greater than 4

--- a/tools/ci/pipeline-baseline-fri.yml
+++ b/tools/ci/pipeline-baseline-fri.yml
@@ -27,7 +27,7 @@ license:
   tags:
     - iotmsw-amd64
   script:
-    - scancode -l --json-pp scancode_report.json $PWD/..
+    - scancode -l --ignore "**/*.tmp/**" --json-pp scancode_report.json $PWD/..
     - jsonschema -i scancode_report.json $PWD/tools/ci/license/license.schema
   artifacts:
     paths:


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
`--list` option is set implicitly to '${executable_target}.map' in CMake versions < `4.x.x`, hence it's only added explicitly in case of CMake versions > `4.0.0`.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
