### PR TITLE
ci: Remove redundant default-jdk installation

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -873,8 +873,6 @@ black-duck:
     - if: ( $SCHEDULED_JOB_TO_RUN == "run-blackduck-scan" )
   script:
     - export PROJECTNAME="${BLACKDUCK_PROJECT_NAME}"
-    - apt update -y
-    - apt install default-jdk -y
     - echo "-------Starting Black Duck Scan-------"
     - bash <(curl -s -L ${BLACKDUCK_DETECT_SCRIPT})
       --blackduck.url="${BLACKDUCK_URL}"

--- a/bsp/common/syscalls_stub.c
+++ b/bsp/common/syscalls_stub.c
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
- * Based on: https://git.trustedfirmware.org/TF-M/trusted-firmware-m.git/tree/platform/ext/common/syscalls_stub.c?id=9ca8a5eb3c85eecee1303dffa262800ea0385584
+ * Based on: https://git.trustedfirmware.org/plugins/gitiles/TF-M/trusted-firmware-m.git/+/9ca8a5eb3c85eecee1303dffa262800ea0385584/platform/ext/common/syscalls_stub.c
  *
  */
 

--- a/release_changes/202507041323.change.md
+++ b/release_changes/202507041323.change.md
@@ -1,1 +1,2 @@
 ci: Remove redundant default-jdk installation
+syscalls-stub: Fix TF-M link

--- a/release_changes/202507041323.change.md
+++ b/release_changes/202507041323.change.md
@@ -1,0 +1,1 @@
+ci: Remove redundant default-jdk installation


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->

`default-jdk` is already installed as part of the internal CI Docker image. Hence, there is no need to reinstall it in `.gitlab-ci.yml`

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
