### PR TITLE
object-detection-app: Fix Yolo model download link

### DIFF
--- a/applications/object_detection/resources/use_case_resources.json
+++ b/applications/object_detection/resources/use_case_resources.json
@@ -2,12 +2,12 @@
     {
         "name": "object_detection",
         "url_prefix": [
-            "https://github.com/emza-vs/ModelZoo/blob/v1.0/object_detection/"
+            "https://github.com/emza-vs/ModelZoo/raw/refs/tags/v1.0/object_detection/"
         ],
         "resources": [
             {
                 "name": "yolo-fastest_192_face_v4.tflite",
-                "url": "{url_prefix:0}yolo-fastest_192_face_v4.tflite?raw=true"
+                "url": "{url_prefix:0}yolo-fastest_192_face_v4.tflite"
             }
         ]
     }

--- a/release_changes/202603241213.change.md
+++ b/release_changes/202603241213.change.md
@@ -1,0 +1,1 @@
+object-detection-app: Fix Yolo model download link


### PR DESCRIPTION
Replace the blob redirect with an unambiguous canonical link in the resource download json config file.

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->

Fix the Object-Detection application by replacing the blob redirect for the Yolo model with an unambiguous canonical link in the resource download json config file.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
